### PR TITLE
Create workflow to run tests in a docker container

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build the Docker image
-        run: docker build . --file Dockerfile --tag ez-recipes-server-ci:$(date +%s)
+        run: docker build . --file Dockerfile --tag ez-recipes-server-ci
       - name: Run tests inside the container
-        run: docker run ez-recipes-server-ci npm test
+        run: docker run -it --rm ez-recipes-server-ci npm test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: docker build . --file Dockerfile --tag ez-recipes-server-ci:$(date +%s)
+      - name: Run tests inside the container
+        run: docker run ez-recipes-server-ci npm test

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Build the Docker image
         run: docker build . --file Dockerfile --tag ez-recipes-server-ci
       - name: Run tests inside the container
-        run: docker run -it --rm ez-recipes-server-ci npm test
+        run: docker run --rm ez-recipes-server-ci npm test


### PR DESCRIPTION
This workflow will validate if the server is working in a Docker container. It will help when node and docker dependencies are regularly updated. Unfortunately, I can only run the tests on the dev Docker container since the dev dependencies are excluded in the prod container to make it smaller and quicker to produce. I'm also unable to do the same on the front end unless I install Chrome on the container, which would unnecessarily bloat the container just for testing.