### PR TITLE
Pass the API key as a header instead of a query parameter

### DIFF
--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -62,10 +62,10 @@ const handleAxiosError = (error: AxiosError): [number, RecipeError] => {
 
 // Get a random, low-effort recipe
 router.get("/random", async (req, res) => {
-  const url = randomRecipeUrlBuilder();
+  const [url, headers] = randomRecipeUrlBuilder();
 
   try {
-    const recipeResponse = await axios.get<SearchResponse>(url);
+    const recipeResponse = await axios.get<SearchResponse>(url, { headers });
     logSpoonacularQuota(req.method, req.originalUrl, recipeResponse);
 
     const recipes = recipeResponse.data;
@@ -88,10 +88,10 @@ router.get("/:id", async (req, res) => {
     return res.status(400).json({ error: "The recipe ID must be numeric" });
   }
 
-  const url = recipeIdUrlBuilder(Number(id));
+  const [url, headers] = recipeIdUrlBuilder(Number(id));
 
   try {
-    const recipeResponse = await axios.get<RecipeResponse>(url);
+    const recipeResponse = await axios.get<RecipeResponse>(url, { headers });
     logSpoonacularQuota(req.method, req.originalUrl, recipeResponse);
 
     const recipes = recipeResponse.data;

--- a/tests/recipeUtils.test.ts
+++ b/tests/recipeUtils.test.ts
@@ -22,34 +22,40 @@ afterEach(() => {
 });
 
 describe("randomRecipeUrlBuilder", () => {
-  test("returns the correct random recipe URL", () => {
+  test("returns the correct random recipe URL & headers", () => {
     // Given query params like the API key
     // Mock the API key to prevent the real one from being leaked when tests fail
     process.env.API_KEY = "384ba039c39e90f";
 
     // When the URL builder method is called
-    const recipeUrl = randomRecipeUrlBuilder();
+    const [recipeUrl, headers] = randomRecipeUrlBuilder();
 
-    // Then it should return the correct spoonacular URL to fetch a random recipe
+    // Then it should return the correct spoonacular URL & headers to fetch a random recipe
     expect(recipeUrl).toBe(
-      `https://api.spoonacular.com/recipes/complexSearch?apiKey=${process.env.API_KEY}&instructionsRequired=true&addRecipeNutrition=true&maxReadyTime=60&sort=random&number=1`
+      `https://api.spoonacular.com/recipes/complexSearch?instructionsRequired=true&addRecipeNutrition=true&maxReadyTime=60&sort=random&number=1`
     );
+    expect(headers).toStrictEqual({
+      "x-api-key": process.env.API_KEY,
+    });
   });
 });
 
 describe("recipeIdUrlBuilder", () => {
-  test("returns the correct URL with the recipe ID", () => {
+  test("returns the correct URL & headers with the recipe ID", () => {
     // Given an API key and a recipe ID
     process.env.API_KEY = "384ba039c39e90f";
     const recipeId = "8427";
 
     // When the URL builder method is called
-    const recipeUrl = recipeIdUrlBuilder(Number(recipeId));
+    const [recipeUrl, headers] = recipeIdUrlBuilder(Number(recipeId));
 
-    // Then it should return the correct spoonacular URL to fetch the recipe from recipeId
+    // Then it should return the correct spoonacular URL & headers to fetch the recipe from recipeId
     expect(recipeUrl).toBe(
-      `https://api.spoonacular.com/recipes/${recipeId}/information?apiKey=${process.env.API_KEY}&includeNutrition=true`
+      `https://api.spoonacular.com/recipes/${recipeId}/information?includeNutrition=true`
     );
+    expect(headers).toStrictEqual({
+      "x-api-key": process.env.API_KEY,
+    });
   });
 });
 

--- a/types/RecipeHeaders.ts
+++ b/types/RecipeHeaders.ts
@@ -1,0 +1,5 @@
+type RecipeHeaders = {
+  "x-api-key": string;
+};
+
+export default RecipeHeaders;

--- a/utils/recipeUtils.ts
+++ b/utils/recipeUtils.ts
@@ -3,6 +3,7 @@ import { AxiosResponse } from "axios";
 import Recipe from "../models/client/Recipe";
 import RecipeResponse from "../models/spoonacular/RecipeResponse";
 import SearchResponse from "../models/spoonacular/SearchResponse";
+import RecipeHeaders from "../types/RecipeHeaders";
 
 /**
  * Build the spoonacular URL to fetch a random, low-effort recipe
@@ -14,23 +15,32 @@ import SearchResponse from "../models/spoonacular/SearchResponse";
  * - 1 hour or less of cook time
  * - Can make 3 or more servings
 
- * @returns {string} an encoded URI
+ * @returns {[string, RecipeHeaders]} an encoded URI and headers
  */
-export const randomRecipeUrlBuilder = (): string => {
+export const randomRecipeUrlBuilder = (): [string, RecipeHeaders] => {
   const apiKey = process.env.API_KEY;
-  let url = `https://api.spoonacular.com/recipes/complexSearch?apiKey=${apiKey}&instructionsRequired=true&addRecipeNutrition=true&maxReadyTime=60&sort=random&number=1`;
-  return encodeURI(url);
+  let url = `https://api.spoonacular.com/recipes/complexSearch?instructionsRequired=true&addRecipeNutrition=true&maxReadyTime=60&sort=random&number=1`;
+  // It's more secure to pass the API key as a header than as a query parameter
+  const headers: RecipeHeaders = {
+    "x-api-key": apiKey ?? "",
+  };
+
+  return [encodeURI(url), headers];
 };
 
 /**
  * Build the spoonacular URL to fetch a recipe by ID
  * @param {number} id the recipe ID
- * @returns {string} an encoded URI
+ * @returns {[string, RecipeHeaders]} an encoded URI and headers
  */
-export const recipeIdUrlBuilder = (id: number): string => {
+export const recipeIdUrlBuilder = (id: number): [string, RecipeHeaders] => {
   const apiKey = process.env.API_KEY;
-  const url = `https://api.spoonacular.com/recipes/${id}/information?apiKey=${apiKey}&includeNutrition=true`;
-  return encodeURI(url);
+  const url = `https://api.spoonacular.com/recipes/${id}/information?includeNutrition=true`;
+  const headers: RecipeHeaders = {
+    "x-api-key": apiKey ?? "",
+  };
+
+  return [encodeURI(url), headers];
 };
 
 /**


### PR DESCRIPTION
This addresses bullet 2 from #45 to more securely pass the API key to spoonacular requests. This is not a breaking change for any of our apps.

Closes #45 