### PR TITLE
Load OpenAPI docs & enable CSP

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,15 +1,35 @@
 import cors from "cors";
 import "dotenv/config"; // fetch secrets from .env
 import express from "express";
+import helmet from "helmet";
+
+import docs from "./routes/docs";
 import recipes from "./routes/recipes";
 
 const app = express();
 
-// Initialize middleware: parse JSON & enable CORS
+/**
+ * Initialize middleware:
+ * - Parse JSON
+ * - Serve Swagger UI files
+ * - Enable CORS
+ * - Add security headers
+ */
 app.use(express.json());
 app.use(cors());
+app.use(
+  helmet({
+    // Customize the CSP header to enable "Try it out"
+    contentSecurityPolicy: {
+      directives: {
+        "connect-src": ["'self'", "ez-recipes-server.onrender.com"],
+      },
+    },
+  })
+);
 
 // Define routes
+app.use("/", docs);
 app.use("/api/recipes", recipes);
 
 // parseInt() requires a string, not undefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,17 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "pm2": "^5.3.0"
+        "helmet": "^7.0.0",
+        "pm2": "^5.3.0",
+        "swagger-ui-express": "^5.0.0",
+        "yaml": "^2.3.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.14",
         "@types/express": "^4.17.17",
         "@types/jest": "^28.1.3",
         "@types/node": "^20.5.9",
+        "@types/swagger-ui-express": "^4.1.3",
         "jest": "^28.1.1",
         "ts-jest": "^28.0.5",
         "ts-node-dev": "^2.0.0",
@@ -1525,6 +1529,16 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -2089,10 +2103,19 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
-      "dev": true
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -2334,9 +2357,9 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3013,6 +3036,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.0.0.tgz",
+      "integrity": "sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/html-escaper": {
@@ -5579,6 +5610,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.6.2.tgz",
+      "integrity": "sha512-2LKVuU2m6RHkemJloKiKJOTpN2RPmbsiad0OfSdtmFHOXJKAgYRZMwJcpT96RX6E9HUB5RkVOFC6vWqVjRgSOg=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/systeminformation": {
       "version": "5.12.7",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.12.7.tgz",
@@ -6177,6 +6227,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/yamljs": {
       "version": "0.3.0",
@@ -7451,6 +7509,16 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "@types/swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-jqCjGU/tGEaqIplPy3WyQg+Nrp6y80DCFnDEAvVKWkJyv0VivSSDCChkppHRHAablvInZe6pijDFMnavtN0vqA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "@types/yargs": {
       "version": "17.0.10",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
@@ -7869,9 +7937,9 @@
       }
     },
     "ci-info": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.2.tgz",
-      "integrity": "sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -8081,9 +8149,9 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true
     },
     "degenerator": {
@@ -8573,6 +8641,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "helmet": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.0.0.tgz",
+      "integrity": "sha512-MsIgYmdBh460ZZ8cJC81q4XJknjG567wzEmv46WOBblDb6TUd3z8/GhgmsM9pn8g2B80tAJ4m5/d3Bi1KrSUBQ=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -10502,6 +10575,19 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "swagger-ui-dist": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.6.2.tgz",
+      "integrity": "sha512-2LKVuU2m6RHkemJloKiKJOTpN2RPmbsiad0OfSdtmFHOXJKAgYRZMwJcpT96RX6E9HUB5RkVOFC6vWqVjRgSOg=="
+    },
+    "swagger-ui-express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.0.tgz",
+      "integrity": "sha512-tsU9tODVvhyfkNSvf03E6FAk+z+5cU3lXAzMy6Pv4av2Gt2xA0++fogwC4qo19XuFf6hdxevPuVCSKFuMHJhFA==",
+      "requires": {
+        "swagger-ui-dist": ">=5.0.0"
+      }
+    },
     "systeminformation": {
       "version": "5.12.7",
       "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.12.7.tgz",
@@ -10881,6 +10967,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "yaml": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg=="
     },
     "yamljs": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,17 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "pm2": "^5.3.0"
+    "helmet": "^7.0.0",
+    "pm2": "^5.3.0",
+    "swagger-ui-express": "^5.0.0",
+    "yaml": "^2.3.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.14",
     "@types/express": "^4.17.17",
     "@types/jest": "^28.1.3",
     "@types/node": "^20.5.9",
+    "@types/swagger-ui-express": "^4.1.3",
     "jest": "^28.1.1",
     "ts-jest": "^28.0.5",
     "ts-node-dev": "^2.0.0",

--- a/routes/docs.ts
+++ b/routes/docs.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import fs from "fs";
+import swaggerUi from "swagger-ui-express";
+import YAML from "yaml";
+
+// Convert the OpenAPI spec from YAML to JSON
+const swaggerFile = fs.readFileSync("./openapi.yaml", "utf8");
+const swaggerDocument: swaggerUi.JsonObject = YAML.parse(swaggerFile);
+
+const router = express.Router();
+router.use("/", swaggerUi.serve);
+router.get("/", swaggerUi.setup(swaggerDocument));
+
+export default router;


### PR DESCRIPTION
<img width="960" alt="image" src="https://github.com/Abhiek187/ez-recipes-server/assets/29958092/be132869-8e58-4b5b-9a32-87c62097cb67">

I was previously using SwaggerHub to host the OpenAPI docs for the server, which is a managed service provided by SmartBear. But, I learned we can host the docs ourselves using Swagger UI. This will allow the docs to automatically update whenever we update `openapi.yaml`.

I originally tried using `swagger-ui-dist` to host the docs, but there wasn't a way I could customize the docs beyond the default pet store API. Workarounds involved modifying content in `node_modules`, which isn't practical in prod. Instead, I used [swagger-ui-express](https://github.com/scottie1984/swagger-ui-express), which allows for customization, integrates better with Express, and is well-supported. I set the root path `/` to point to the OpenAPI docs. (I will update the link in the README once the doc is successfully deployed.) The recipe API remains intact.

In addition, I improved the security of the API using `helmet`, which adds all the necessary security headers to every API call. To get "Try this out" to work in the Swagger docs, I added a `content-src` entry so the docs can connect to the server for testing. (I don't think this is necessary in prod since the server and API docs are hosted in the same domain, but this is needed when testing locally.)