### PR TITLE
152 enable full text search for recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 This is an API built using Express to fetch low-effort recipes from [spoonacular](https://spoonacular.com/food-api). These are recipes that can be made within an hour, use common kitchen ingredients, and can produce multiple servings. It's ideal for new chefs learning how to cook, or people with little free time who want to cook something tasty. This API is connected to the [web](https://github.com/Abhiek187/ez-recipes-web), [iOS](https://github.com/Abhiek187/ez-recipes-ios), and [Android](https://github.com/Abhiek187/ez-recipes-android) apps so anyone can view the recipes on any device.
 
-In addition to spoonacular, MongoDB is used to cache the recipes for improved query performance.
+In addition to spoonacular, MongoDB is used to cache the recipes for improved query performance. It is also used to perform full-text search on recipes based on various criteria like recipe name, description, or ingredients.
 
 ### Architecture Diagram
 
@@ -36,7 +36,7 @@ Server-->>Client: Client recipe
 
 - TypeScript for added type safety
 - RESTful APIs
-- MongoDB to store and query recipe data
+- MongoDB to store data, query data, and do full-text search
 - Docker to containerize the server on any machine
 - OpenAPI to publish standardized API documentation
 - GitHub Actions for automated testing and deployment in a CI/CD pipeline

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,6 +15,12 @@ paths:
       summary: Get recipes by filters
       parameters:
         - in: query
+          name: query
+          schema:
+            type: string
+            minLength: 1
+          description: Search query
+        - in: query
           name: min-cals
           schema:
             type: number

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -14,12 +14,7 @@ import {
 } from "../utils/recipeUtils";
 import { isNumeric } from "../utils/string";
 import api, { handleAxiosError } from "../utils/api";
-import {
-  fetchRecipe,
-  filterRecipes,
-  saveRecipe,
-  searchRecipes,
-} from "../utils/db";
+import { fetchRecipe, filterRecipes, saveRecipe } from "../utils/db";
 import RecipeFilter from "../types/client/RecipeFilter";
 import {
   isValidSpiceLevel,
@@ -50,26 +45,17 @@ router.get("/", async (req, res) => {
     type,
     culture,
   } = req.query;
+  const filter: Partial<RecipeFilter> = {};
 
+  // Sanitize all the query parameters
   if (typeof query === "string") {
     if (query.length === 0) {
       return badRequestError(res, "Search query cannot be empty");
     }
 
-    const recipes = await searchRecipes(query);
-
-    if (recipes === null) {
-      return res
-        .status(500)
-        .json({ error: "Failed to search recipes. Please try again later." });
-    }
-
-    return res.json(recipes);
+    filter.query = query;
   }
 
-  const filter: Partial<RecipeFilter> = {};
-
-  // Sanitize all the query parameters
   try {
     if (minCals !== undefined) {
       filter.minCals = sanitizeNumber(minCals, "min-cals", 0, 2000);

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -14,7 +14,12 @@ import {
 } from "../utils/recipeUtils";
 import { isNumeric } from "../utils/string";
 import api, { handleAxiosError } from "../utils/api";
-import { fetchRecipe, filterRecipes, saveRecipe } from "../utils/db";
+import {
+  fetchRecipe,
+  filterRecipes,
+  saveRecipe,
+  searchRecipes,
+} from "../utils/db";
 import RecipeFilter from "../types/client/RecipeFilter";
 import {
   isValidSpiceLevel,
@@ -32,6 +37,7 @@ const router = express.Router();
 router.get("/", async (req, res) => {
   console.log(`${req.method} ${req.originalUrl}`);
   const {
+    query,
     "min-cals": minCals,
     "max-cals": maxCals,
     vegetarian,
@@ -44,6 +50,23 @@ router.get("/", async (req, res) => {
     type,
     culture,
   } = req.query;
+
+  if (typeof query === "string") {
+    if (query.length === 0) {
+      return badRequestError(res, "Search query cannot be empty");
+    }
+
+    const recipes = await searchRecipes(query);
+
+    if (recipes === null) {
+      return res
+        .status(500)
+        .json({ error: "Failed to search recipes. Please try again later." });
+    }
+
+    return res.json(recipes);
+  }
+
   const filter: Partial<RecipeFilter> = {};
 
   // Sanitize all the query parameters

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -1,4 +1,4 @@
-import { isObject } from "../utils/object";
+import { isEmptyObject, isObject } from "../utils/object";
 import { expectedRecipe, mockSearchResponse } from "./recipeUtils.test";
 
 describe("isObject", () => {
@@ -41,4 +41,32 @@ describe("isObject", () => {
     // Then they should all return false
     expect(isObject(obj)).toBe(false);
   });
+});
+
+describe("isEmptyObject", () => {
+  it.each([
+    {},
+    Number(),
+    Error(),
+    Object(),
+    Object.create(null),
+    Object.create({}),
+    Math,
+    JSON,
+  ])("passes all positive cases", (obj) => {
+    // Given a set of objects that are empty
+    // When passed to isEmptyObject
+    // They they should all return true
+    expect(isEmptyObject(obj)).toBe(true);
+  });
+
+  it.each([{ not: "empty" }, { "": {} }, mockSearchResponse, expectedRecipe])(
+    "passes all negative cases",
+    (obj) => {
+      // Given a set of objects that aren't empty
+      // When passed to isEmptyObject
+      // They they should all return false
+      expect(isEmptyObject(obj)).toBe(false);
+    }
+  );
 });

--- a/types/client/RecipeFilter.ts
+++ b/types/client/RecipeFilter.ts
@@ -1,6 +1,7 @@
 import { Cuisine, MealType, SpiceLevel } from "./Recipe";
 
 type RecipeFilter = {
+  query: string;
   minCals: number;
   maxCals: number;
   vegetarian: boolean;

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -3,6 +3,12 @@ import mongoose from "mongoose";
 import Recipe from "../types/client/Recipe";
 import RecipeModel from "../models/RecipeModel";
 import RecipeFilter from "../types/client/RecipeFilter";
+import { isEmptyObject } from "./object";
+
+// MongoDB indexes
+export const Indexes = {
+  RecipeName: "recipe-name",
+} as const;
 
 /**
  * Connect to MongoDB using mongoose
@@ -49,12 +55,7 @@ export const fetchRecipe = async (id: number): Promise<Recipe | null> => {
   }
 };
 
-/**
- * Query recipes by the provided filters
- * @param filter an object describing how to filter the recipes
- * @returns a list of recipes, or `null` if an error occurred
- */
-export const filterRecipes = async ({
+const createQuery = ({
   minCals,
   maxCals,
   vegetarian,
@@ -66,7 +67,8 @@ export const filterRecipes = async ({
   spiceLevels,
   types,
   cultures,
-}: Partial<RecipeFilter>): Promise<Recipe[] | null> => {
+}: Partial<RecipeFilter>): mongoose.FilterQuery<Recipe> => {
+  // Create a find/match query for MongoDB
   let query: mongoose.FilterQuery<Recipe> = {};
 
   if (minCals !== undefined) {
@@ -122,32 +124,70 @@ export const filterRecipes = async ({
     query.culture = { $in: cultures };
   }
 
+  return query;
+};
+
+const recipeFindQuery = async (
+  filter: Partial<RecipeFilter>
+): Promise<Recipe[] | null> => {
+  const findQuery = createQuery(filter);
+  console.log("MongoDB find query:", JSON.stringify(findQuery));
+
   try {
-    console.log("MongoDB query:", JSON.stringify(query));
-    return await RecipeModel.find(query).exec();
+    return await RecipeModel.find(findQuery).exec();
   } catch (error) {
     console.error("Failed to filter recipes:", error);
     return null;
   }
 };
 
-export const searchRecipes = async (
-  query: string
+const recipeAggregateQuery = async (
+  // Query key is required, everything else is optional
+  filter: Partial<RecipeFilter>
 ): Promise<Recipe[] | null> => {
+  const matchQuery = createQuery(filter);
+  console.log("MongoDB match query:", JSON.stringify(matchQuery));
+
+  /*
+   * Search must be the first stage in the pipeline before $match.
+   * If performance becomes an issue, try following this guide:
+   * https://www.mongodb.com/docs/atlas/atlas-search/performance/query-performance/#-match-aggregation-stage-usage
+   */
+  let pipeline = RecipeModel.aggregate().search({
+    index: Indexes.RecipeName,
+    text: {
+      query: filter.query,
+      path: {
+        wildcard: "*",
+      },
+    },
+  });
+
+  if (!isEmptyObject(matchQuery)) {
+    pipeline = pipeline.match(matchQuery);
+  }
+
   try {
-    return await RecipeModel.aggregate()
-      .search({
-        index: "recipe-name",
-        text: {
-          query,
-          path: {
-            wildcard: "*",
-          },
-        },
-      })
-      .exec();
+    return await pipeline.exec();
   } catch (error) {
     console.error("Failed to search recipes:", error);
     return null;
+  }
+};
+
+/**
+ * Query recipes by the provided filters
+ * @param filter an object describing how to filter the recipes
+ * @returns a list of recipes, or `null` if an error occurred
+ */
+export const filterRecipes = async (
+  filter: Partial<RecipeFilter>
+): Promise<Recipe[] | null> => {
+  if (filter.query !== undefined) {
+    // If a full-text search is required, use an aggregation pipeline
+    return await recipeAggregateQuery(filter);
+  } else {
+    // Otherwise, use a simple find query
+    return await recipeFindQuery(filter);
   }
 };

--- a/utils/db.ts
+++ b/utils/db.ts
@@ -130,3 +130,24 @@ export const filterRecipes = async ({
     return null;
   }
 };
+
+export const searchRecipes = async (
+  query: string
+): Promise<Recipe[] | null> => {
+  try {
+    return await RecipeModel.aggregate()
+      .search({
+        index: "recipe-name",
+        text: {
+          query,
+          path: {
+            wildcard: "*",
+          },
+        },
+      })
+      .exec();
+  } catch (error) {
+    console.error("Failed to search recipes:", error);
+    return null;
+  }
+};

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -9,3 +9,20 @@
  */
 export const isObject = (data: any): boolean =>
   typeof data === "object" && !Array.isArray(data) && data !== null;
+
+/**
+ * Check if an object is empty (excluding inherited properties)
+ *
+ * Source: https://stackoverflow.com/a/32108184
+ * @param object the object to check
+ * @returns true if `object` is empty, false otherwise
+ */
+export const isEmptyObject = (object: Record<string, unknown>) => {
+  for (const prop in object) {
+    if (Object.hasOwn(object, prop)) {
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
<img width="775" alt="full-text search index overview" src="https://github.com/Abhiek187/ez-recipes-server/assets/29958092/d4ec9bfe-a699-4d30-a75f-aaa809b53a7f">

One of the big reasons I went for MongoDB was that it provided full-text search capabilities for free (under the M0 tier) and was easy to set up. I created an index in Atlas and used the default settings to enable full-text search. This will be a great feature for EZ Recipes to implement a search bar for recipes, beyond just comparing strings.

I did plenty of testing in Postman, but I feel it will be easier to test the search relevancy once we implement this feature in the UI and provide some visual feedback.

It'll also be handy for performance testing. One thing of note is that full-text search requires creating an aggregation pipeline, but not the rest of the filters. I saw that MongoDB's docs mention about a [performance degradation](https://www.mongodb.com/docs/atlas/atlas-search/performance/query-performance/#-match-aggregation-stage-usage) when using `$match` after `$search` in a pipeline. That makes sense since you would be unnecessarily searching documents that would be filtered anyway, but I can't place `$match` before `$search` since `$search` must be the first stage. MongoDB recommends using the `compound` operator to do the filtering in the `$search` stage, but that is a different syntax from the regular find/$match (MQL) query syntax. And I'm not sure how compatible it is with more complex queries like `$elemMatch`. I could explore that in the future if performance becomes a problem, but for now, it's simpler for me to add a `$match` stage since I can just copy the same `find` query syntax from before.