### PR TITLE
Don't return an error for empty queries

### DIFF
--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -49,11 +49,7 @@ router.get("/", async (req, res) => {
 
   // Sanitize all the query parameters
   if (typeof query === "string") {
-    if (query.length === 0) {
-      return badRequestError(res, "Search query cannot be empty");
-    }
-
-    filter.query = query;
+    filter.query = query || undefined; // ignore empty queries
   }
 
   try {


### PR DESCRIPTION
Since some clients have trouble omitting query parameters if they're empty, I relaxed the server a bit to just ignore empty queries (and treat them like regular `find` queries).