### PR TITLE
Feature/paginate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Server-->>Client: Client recipe
 - TypeScript for added type safety
 - RESTful APIs
 - MongoDB to store data, query data, and do full-text search
+- Pagination to reduce bandwidth and optimize query performance
 - Docker to containerize the server on any machine
 - OpenAPI to publish standardized API documentation
 - GitHub Actions for automated testing and deployment in a CI/CD pipeline

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: EZ Recipes
   description: An API that fetches recipes from spoonacular and MongoDB
-  version: 2.1.0
+  version: 2.2.0
 
 servers:
   - url: https://ez-recipes-server.onrender.com
@@ -12,7 +12,7 @@ servers:
 paths:
   /api/recipes:
     get:
-      summary: Get recipes by filters
+      summary: Get up to 100 recipes by filters. Pagination is required to return more recipes.
       parameters:
         - in: query
           name: query
@@ -157,6 +157,14 @@ paths:
                 - "South American"
                 - Creole
           description: Cuisines
+        - in: query
+          name: token
+          schema:
+            type: string
+          description: >
+            A token used to paginate results.
+            If no query is passed, this is the ObjectId of the recipe to search after.
+            If a query is passed, this is the token returned from a previous query.
       responses:
         "200":
           description: Successfully filtered recipes
@@ -287,9 +295,13 @@ components:
       type: array
       items:
         $ref: "#/components/schemas/recipe"
+      maxItems: 100
     recipe:
       type: object
       properties:
+        _id:
+          type: string
+          description: The ObjectId of a recipe as stored in MongoDB
         id:
           type: integer
           minimum: 0
@@ -465,6 +477,11 @@ components:
                             description: >
                               The name of the equipment's image. The image's URL would be
                               https://spoonacular.com/cdn/equipment_100x100/IMAGE
+        token:
+          type: string
+          description: >
+            A base64 token that can be used to paginate additional recipes.
+            Only returned if a query was passed.
     error:
       type: object
       properties:

--- a/types/client/Recipe.ts
+++ b/types/client/Recipe.ts
@@ -127,6 +127,7 @@ type Recipe = {
       }[];
     }[];
   }[];
+  token?: string; // searchSequenceToken for pagination
 };
 
 export default Recipe;

--- a/types/client/RecipeFilter.ts
+++ b/types/client/RecipeFilter.ts
@@ -13,6 +13,7 @@ type RecipeFilter = {
   spiceLevels: Exclude<SpiceLevel, "unknown">[];
   types: MealType[];
   cultures: Cuisine[];
+  token?: string; // either an ObjectId or searchSequenceToken for pagination
 };
 
 export default RecipeFilter;


### PR DESCRIPTION
Server-side implementation of #199 

I followed the steps in the above issue to limit the number of results to 100 and add pagination to both find and aggregate queries. mongoose provides a helper function to check if an ObjectId is valid, but I wasn't sure how to validate if a searchSequenceToken was valid. It seems to do more checks beyond just being base64. (I also learned that this is a relatively new feature of MongoDB Atlas, hence why there isn't as much discussion surrounding it.) As a result, I let the query run and check to see if the following error appears:
> MongoServerError: "searchAfter" Invalid format for token value

I updated the OpenAPI docs to clarify what kind of token needs to be passed to the filter API. It's important to note that the `token` returned from the API will only be a search token since we reference `_id` for find queries. As such, I included that as a property in the recipe object. I believe all the clients will need to include that property in their types as well. `id` can still behave like a primary key for the recipes, while `_id` is specific to MongoDB.