### PR TITLE
290 manage refresh tokens on the server side

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -103,6 +103,9 @@ components:
           type: string
           description: The chef's email
           format: email
+        token:
+          type: string
+          description: The ID token for the chef
 
   examples:
     invalidEmail:

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "firebase": "^10.14.0",
         "firebase-admin": "^12.6.0",
         "helmet": "^8.0.0",
+        "jwt-decode": "^4.0.0",
         "mongoose": "^8.6.3",
         "pm2": "^5.4.2",
         "swagger-ui-express": "^5.0.1",
@@ -6787,6 +6788,15 @@
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kareem": {
@@ -15015,6 +15025,11 @@
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA=="
     },
     "kareem": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "firebase": "^10.14.0",
     "firebase-admin": "^12.6.0",
     "helmet": "^8.0.0",
+    "jwt-decode": "^4.0.0",
     "mongoose": "^8.6.3",
     "pm2": "^5.4.2",
     "swagger-ui-express": "^5.0.1",

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -53,7 +53,10 @@ router.post("/verify", auth, async (_req, res) => {
   try {
     const emailResponse = await verifyEmail(token);
     console.log(`Sending verification email to ${emailResponse.email}...`);
-    res.json(emailResponse);
+    res.json({
+      ...emailResponse,
+      token,
+    });
   } catch (error) {
     if (isAxiosError(error) && isFirebaseRestError(error.response?.data)) {
       const { code, message } = error.response.data.error;


### PR DESCRIPTION
No paths were added here, though I did modify `POST /verify` to include the token in the response. This should be the case for all protected endpoints since the token could be refreshed at any point.

All the helper methods were implemented as part of #291. I added the refresh logic in the middleware, so if the token is expired, we try to refresh it and use it as part of the request. Since Firebase won't decode the token if it's expired, I installed a lightweight package to decode manually. This was mainly to get the UID to identify which refresh token should be used.

Since I forgot to show this in the last PR, here's an example of how a chef is stored in MongoDB, with the encrypted refresh token:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/65e40614-283f-4865-847f-dcd2006383f3">