### PR TITLE
Add an endpoint to view the chef's profile

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -1,5 +1,36 @@
 paths:
   /:
+    get:
+      summary: Get the chef's profile
+      tags:
+        - chefs
+      security:
+        - bearerAuth: [] # no scopes for bearer auth
+      responses:
+        "200":
+          description: Successfully fetched the chef's profile
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/userProfile"
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                missingToken:
+                  $ref: "#/components/examples/missingToken"
+
+        "404":
+          description: The chef couldn't be found
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
     post:
       summary: Create an account
       tags:
@@ -44,7 +75,7 @@ paths:
       tags:
         - chefs
       security:
-        - bearerAuth: [] # no scopes for bearer auth
+        - bearerAuth: []
       responses:
         "200":
           description: Successfully sent a verification email
@@ -64,11 +95,48 @@ paths:
                   $ref: "#/components/examples/tooManyAttempts"
                 userNotFound:
                   $ref: "#/components/examples/userNotFound"
-                tokenExpired:
-                  $ref: "#/components/examples/tokenExpired"
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                missingToken:
+                  $ref: "#/components/examples/missingToken"
 
 components:
   schemas:
+    userProfile:
+      type: object
+      properties:
+        uid:
+          type: string
+          description: The unique identifier for the chef
+        email:
+          type: string
+          description: The chef's email address
+          format: email
+        ratings:
+          type: object
+          description: >-
+            Key-value pairs, where the key is the recipe ID and the value is the rating given
+          additionalProperties:
+            type: integer
+        recentRecipes:
+          type: array
+          items:
+            type: string
+            description: The ID of a recipe recently viewed
+        favoriteRecipes:
+          type: array
+          items:
+            type: string
+            description: The ID of a favorite recipe
+        token:
+          type: string
+          description: The ID token for the chef
     credentials:
       type: object
       properties:
@@ -123,8 +191,8 @@ components:
         {
           "error": "Invalid Firebase token provided: Error: There is no user record corresponding to the provided identifier.",
         }
-    tokenExpired:
+    missingToken:
       value:
         {
-          "error": "Invalid Firebase token provided: Error: Firebase ID token has expired. Get a fresh ID token from your client app and try again (auth/id-token-expired). See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.",
+          "error": "Invalid Firebase token provided: Error: Decoding Firebase ID token failed. Make sure you passed the entire string JWT which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.",
         }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -49,6 +49,8 @@ components:
     terms:
       $ref: "./docs/terms.yaml#/components/schemas/terms"
 
+    userProfile:
+      $ref: "./docs/chefs.yaml#/components/schemas/userProfile"
     credentials:
       $ref: "./docs/chefs.yaml#/components/schemas/credentials"
     userInfo:

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -10,8 +10,32 @@ import auth from "../middleware/auth";
 import { verifyEmail } from "../utils/auth/api";
 import { isFirebaseRestError } from "../types/firebase/FirebaseRestError";
 import { handleAxiosError } from "../utils/api";
+import { getChef } from "../utils/db";
+import { filterObject } from "../utils/object";
 
 const router = express.Router();
+
+router.get("/", auth, async (_req, res) => {
+  // Get the user's profile
+  const { token, uid } = res.locals;
+  const chef = await getChef(uid);
+
+  if (chef === null) {
+    // Shouldn't normally occur, unless MongoDB is out-of-sync with Firebase
+    res.status(404).json({ error: `Chef with UID ${uid} not found` });
+  } else {
+    res.status(200).json({
+      uid,
+      ...filterObject(chef, [
+        "email",
+        "ratings",
+        "recentRecipes",
+        "favoriteRecipes",
+      ]),
+      token,
+    });
+  }
+});
 
 router.post(
   "/",

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -1,4 +1,4 @@
-import { isEmptyObject, isObject } from "../utils/object";
+import { filterObject, isEmptyObject, isObject } from "../utils/object";
 import { expectedRecipe, mockSearchResponse } from "./recipeUtils.test";
 
 describe("isObject", () => {
@@ -67,4 +67,37 @@ describe("isEmptyObject", () => {
       expect(isEmptyObject(obj)).toBe(false);
     }
   );
+});
+
+describe("filterObject", () => {
+  const object = { a: 1, b: "is", c: true };
+
+  it("creates an identical object if all keys are passed", () => {
+    const keys = ["a", "b", "c"];
+    const filteredObject = filterObject(object, keys);
+
+    expect(Object.is(object, filteredObject)).toBe(false);
+    expect(object).toMatchObject(filteredObject);
+  });
+
+  it("filters some keys in the object", () => {
+    const keys = ["a", "c"];
+    const filteredObject = filterObject(object, keys);
+
+    expect(Object.keys(filteredObject).sort()).toEqual(keys.sort());
+  });
+
+  it("returns an empty object if no keys are passed", () => {
+    const keys: string[] = [];
+    const filteredObject = filterObject(object, keys);
+
+    expect(isEmptyObject(filteredObject)).toBe(true);
+  });
+
+  it("ignores keys not present in the object", () => {
+    const keys = ["b", "d"];
+    const filteredObject = filterObject(object, keys);
+
+    expect(Object.keys(filteredObject).sort()).toEqual(["b"]);
+  });
 });

--- a/utils/db/chefs.ts
+++ b/utils/db/chefs.ts
@@ -28,6 +28,21 @@ export const createChef = async (uid: string, email: string) => {
 };
 
 /**
+ * Get a chef by their UID
+ * @param uid the UID of the chef
+ * @returns the chef's document, or `null` if the chef couldn't be found
+ */
+export const getChef = async (uid: string): Promise<Chef | null> => {
+  try {
+    // Return a POJO instead of a Document so filterObject works
+    return await ChefModel.findOne({ _id: uid }).lean().exec();
+  } catch (error) {
+    console.error("Failed to find chef", `${uid}:`, error);
+    return null;
+  }
+};
+
+/**
  * Store the chef's refresh token encrypted in the DB
  * @param uid the UID of the chef
  * @param refreshToken the chef's refresh token

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -26,3 +26,19 @@ export const isEmptyObject = (object: Record<string, unknown>) => {
 
   return true;
 };
+
+/**
+ * Filter an object by certain keys
+ * @param object the object to filter
+ * @param keys an array of keys to keep in the object,
+ * if the key doesn't exist in `object`, it's ignored
+ * @returns a new object only containing the keys passed
+ */
+export const filterObject = <T extends string>(
+  object: { [key in T]: unknown },
+  keys: T[]
+): typeof object => {
+  return Object.fromEntries(
+    Object.entries(object).filter(([key]) => keys.includes(key as T))
+  ) as typeof object;
+};


### PR DESCRIPTION
## GET /api/chefs

Requires auth

Sample response:

```json
{
    "uid": "oJG5PZ8KIIfvQMDsQzOwDbu2m6O2",
    "email": "test@email.com",
    "ratings": {},
    "recentRecipes": [],
    "favoriteRecipes": [],
    "token": "eyJ..."
}
```

This was simple to implement. I didn't end up using the `getUser` method in the Admin SDK. Instead, I returned the information from MongoDB plus any information obtained from the token itself. I'm glad I finally have a GET call I can rely on to make sure I'm still logged in. (I split up these stories so well that it's hard to ramble in these PRs! 😄)

I guess one other interesting thing I learned is how Mongoose returns results. Normally, it returns a `Document` with extra fluff to work well with Mongoose's custom methods. But to make it work with a helper object method I created, I needed to convert the return type to a POJO (plain old JS object). That's where `lean()` comes into play. It's funny how I discovered this bug even after I wrote unit tests for that method.