### PR TITLE
279 create endpoint to login/logout

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -106,6 +106,65 @@ paths:
                 missingToken:
                   $ref: "#/components/examples/missingToken"
 
+  /login:
+    post:
+      summary: Login to the chef's account
+      tags:
+        - chefs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/credentials"
+      responses:
+        "200":
+          description: Successfully logged in
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/userInfo"
+
+        "400":
+          description: The request body is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                invalidEmail:
+                  $ref: "#/components/examples/invalidEmail"
+                invalidCredentials:
+                  $ref: "#/components/examples/invalidCredentials"
+
+  /logout:
+    post:
+      summary: Logout by revoking all existing tokens
+      tags:
+        - chefs
+      security:
+        - bearerAuth: []
+      response:
+        "204":
+          description: Successfully logged out
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                missingToken:
+                  $ref: "#/components/examples/missingToken"
+
+        "500":
+          description: An error occurred while logging out
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
 components:
   schemas:
     userProfile:
@@ -196,3 +255,5 @@ components:
         {
           "error": "Invalid Firebase token provided: Error: Decoding Firebase ID token failed. Make sure you passed the entire string JWT which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.",
         }
+    invalidCredentials:
+      value: { "error": "Failed to login: INVALID_LOGIN_CREDENTIALS" }

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -139,7 +139,7 @@ paths:
 
   /logout:
     post:
-      summary: Logout by revoking all existing tokens
+      summary: Logout of the chef's account
       tags:
         - chefs
       security:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,6 +25,10 @@ paths:
     $ref: "./docs/chefs.yaml#/paths/~1"
   /api/chefs/verify:
     $ref: "./docs/chefs.yaml#/paths/~1verify"
+  /api/chefs/login:
+    $ref: "./docs/chefs.yaml#/paths/~1login"
+  /api/chefs/logout:
+    $ref: "./docs/chefs.yaml#/paths/~1logout"
 
 # Components to be shown on the main page
 components:

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -1,5 +1,5 @@
 import { isAxiosError } from "axios";
-import express, { Response } from "express";
+import express from "express";
 import { body, validationResult } from "express-validator";
 import { FirebaseAuthError } from "firebase-admin/auth";
 
@@ -14,7 +14,7 @@ import { filterObject } from "../utils/object";
 const handleFirebaseRestError = (
   prefix: string,
   error: unknown,
-  res: Response
+  res: express.Response
 ) => {
   if (isAxiosError(error) && isFirebaseRestError(error.response?.data)) {
     const { code, message } = error.response.data.error;

--- a/types/firebase/FirebaseLoginResponse.ts
+++ b/types/firebase/FirebaseLoginResponse.ts
@@ -1,0 +1,12 @@
+type FirebaseLoginResponse = {
+  kind: string;
+  localId: string; // UID
+  email: string;
+  displayName: string;
+  idToken: string;
+  registered: boolean;
+  refreshToken: string;
+  expiresIn: string;
+};
+
+export default FirebaseLoginResponse;

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -91,6 +91,18 @@ export default class FirebaseAdmin {
   }
 
   /**
+   * Log out the user by revoking their tokens
+   * @param uid the unique ID of the user
+   * @throws `FirebaseAuthError` if an error occurred
+   */
+  async logoutUser(uid: string) {
+    const auth = getAuth();
+    await auth.revokeRefreshTokens(uid);
+
+    console.log(`Revoked refresh tokens for user ${uid}`);
+  }
+
+  /**
    * Delete a user from Firebase & MongoDB, if it exists
    * @param uid the unique ID of the user
    * @throws `FirebaseAuthError` if an error occurred

--- a/utils/auth/api.ts
+++ b/utils/auth/api.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import VerifyEmailResponse from "../../types/firebase/VerifyEmailResponse";
 import FirebaseTokenResponse from "../../types/firebase/FirebaseTokenResponse";
 import FirebaseTokenExchangeResponse from "../../types/firebase/FirebaseTokenExchangeResponse";
+import FirebaseLoginResponse from "../../types/firebase/FirebaseLoginResponse";
 
 const idApi = axios.create({
   baseURL: "https://identitytoolkit.googleapis.com/v1",
@@ -33,6 +34,28 @@ export const exchangeCustomToken = async (
     "/accounts:signInWithCustomToken",
     {
       token: customToken,
+      returnSecureToken: true,
+    }
+  );
+  return response.data;
+};
+
+/**
+ * Login the user using their email and password
+ * @param email the user's email
+ * @param password the user's password
+ * @throws `FirebaseRestError` if an error occurred
+ * @returns the user's UID, tokens, and other information
+ */
+export const login = async (
+  email: string,
+  password: string
+): Promise<FirebaseLoginResponse> => {
+  const response = await idApi.post<FirebaseLoginResponse>(
+    "/accounts:signInWithPassword",
+    {
+      email,
+      password,
       returnSecureToken: true,
     }
   );


### PR DESCRIPTION
## POST /login

Sample request body:

```json
{
    "email": "test@email.com",
    "password": "***"
}
```

Sample response body:

```json
{
    "uid": "string",
    "token": "ID_TOKEN",
    "emailVerified": true
}
```

## POST /logout

Requires auth, empty response body

I modified the existing login & logout endpoints to use the REST API & Admin SDK respectively instead of the client SDK. Login is straightforward and uses the same schema as the create endpoint. Logging out revokes both the refresh and ID token, so the user will get an error if they try hitting one of the protected endpoints:

```json
{
    "error": "Invalid Firebase token provided: Error: The Firebase ID token has been revoked."
}
```

The only holdover left is the delete endpoint. Then I should be able to delete those files.