### PR TITLE
280 add endpoint to change username/password

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -70,10 +70,13 @@ paths:
                   $ref: "#/components/examples/emailAlreadyTaken"
 
     patch:
-      summary: Send an email to change the chef's credentials
+      summary: >-
+        Send an email to change the chef's credentials.
+        An ID token is optional if changing passwords.
       tags:
         - chefs
       security:
+        - {} # no security
         - bearerAuth: []
       requestBody:
         required: true
@@ -274,6 +277,8 @@ components:
           format: email
     email:
       type: object
+      # token may not be there if changing passwords
+      required: ["kind", "email"]
       properties:
         kind:
           type: string

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -31,6 +31,13 @@ paths:
               schema:
                 $ref: "..#/components/schemas/error"
 
+        "500":
+          description: An error occurred while fetching the chef's profile
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
     post:
       summary: Create an account
       tags:

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -272,7 +272,6 @@ components:
           description: Whether or not the email address is verified
     changeRequest:
       type: object
-      required: ["type"]
       properties:
         type:
           type: string

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -69,6 +69,46 @@ paths:
                 emailAlreadyTaken:
                   $ref: "#/components/examples/emailAlreadyTaken"
 
+    patch:
+      summary: Send an email to change the chef's credentials
+      tags:
+        - chefs
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/changeRequest"
+      responses:
+        "200":
+          description: Successfully sent an email to verify the change request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/email"
+
+        "400":
+          description: The request body is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                invalidEmail:
+                  $ref: "#/components/examples/invalidEmail"
+
+        "500":
+          description: An error occurred while changing the credentials
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                emailAlreadyTaken:
+                  $ref: "#/components/examples/emailAlreadyTaken"
+
   /verify:
     post:
       summary: Verify the chef's account
@@ -220,6 +260,18 @@ components:
         emailVerified:
           type: boolean
           description: Whether or not the email address is verified
+    changeRequest:
+      type: object
+      required: ["type"]
+      properties:
+        type:
+          type: string
+          enum: ["email", "password"]
+          description: The field to update (email = change email, password = reset password)
+        email:
+          type: string
+          description: The email address to send a verification to
+          format: email
     email:
       type: object
       properties:

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -3,7 +3,7 @@ import { FirebaseAuthError } from "firebase-admin/auth";
 import { jwtDecode } from "jwt-decode";
 
 import FirebaseAdmin from "../utils/auth/admin";
-import { refreshIdToken } from "../utils/auth/api";
+import FirebaseApi from "../utils/auth/api";
 import { getRefreshToken, saveRefreshToken } from "../utils/db";
 
 const saveTokenAndContinue = (
@@ -66,7 +66,7 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
           id_token: newIdToken,
           refresh_token: newRefreshToken,
           user_id: newUid,
-        } = await refreshIdToken(refreshToken);
+        } = await FirebaseApi.instance.refreshIdToken(refreshToken);
 
         await saveRefreshToken(newUid, newRefreshToken);
         saveTokenAndContinue(res, next, newUid, newIdToken);

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -24,11 +24,19 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
   const token = authHeader?.startsWith("Bearer ")
     ? authHeader.split("Bearer ")[1]
     : authHeader;
+  const isChangingPassword =
+    req.url === "/" && req.method === "PATCH" && req.body.type === "password";
 
   if (token === undefined) {
-    res
-      .status(401)
-      .json({ error: "Missing the Firebase ID token from the request" });
+    // Skip validation if changing passwords
+    if (isChangingPassword) {
+      next();
+    } else {
+      res
+        .status(401)
+        .json({ error: "Missing the Firebase ID token from the request" });
+    }
+
     return;
   }
 

--- a/models/ChefModel.ts
+++ b/models/ChefModel.ts
@@ -3,7 +3,6 @@ import Chef from "../types/client/Chef";
 
 const ChefSchema = new Schema<Chef>({
   _id: { type: String, required: true },
-  email: { type: String, required: true },
   refreshToken: { type: String, default: null },
   ratings: { type: Map, of: Number, required: true },
   recentRecipes: { type: [String], required: true },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,5 +59,7 @@ components:
       $ref: "./docs/chefs.yaml#/components/schemas/credentials"
     userInfo:
       $ref: "./docs/chefs.yaml#/components/schemas/userInfo"
+    changeRequest:
+      $ref: "./docs/chefs.yaml#/components/schemas/changeRequest"
     email:
       $ref: "./docs/chefs.yaml#/components/schemas/email"

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -1,15 +1,31 @@
 import { isAxiosError } from "axios";
 import express from "express";
 import { body, validationResult } from "express-validator";
+import { Request } from "express-validator/lib/base";
 import { FirebaseAuthError } from "firebase-admin/auth";
 
 import FirebaseAdmin from "../utils/auth/admin";
 import auth from "../middleware/auth";
-import { login, verifyEmail } from "../utils/auth/api";
+import {
+  changeEmail,
+  login,
+  resetPassword,
+  verifyEmail,
+} from "../utils/auth/api";
 import { isFirebaseRestError } from "../types/firebase/FirebaseRestError";
 import { handleAxiosError } from "../utils/api";
 import { getChef, saveRefreshToken } from "../utils/db";
 import { filterObject } from "../utils/object";
+
+const checkValidations = (req: Request, res: express.Response) => {
+  const validationErrors = validationResult(req);
+  if (!validationErrors.isEmpty()) {
+    const errorMessages = validationErrors.array().map((error) => error.msg);
+    res
+      .status(400)
+      .json({ error: `Invalid request: ${errorMessages.join(" | ")}` });
+  }
+};
 
 const handleFirebaseRestError = (
   prefix: string,
@@ -67,14 +83,8 @@ router.post(
     .withMessage("Password must be at least 8 characters long"),
   async (req, res) => {
     // Create an account
-    const validationErrors = validationResult(req);
-    if (!validationErrors.isEmpty()) {
-      const errorMessages = validationErrors.array().map((error) => error.msg);
-      res
-        .status(400)
-        .json({ error: `Invalid request: ${errorMessages.join(" | ")}` });
-      return;
-    }
+    checkValidations(req, res);
+    if (res.writableEnded) return;
 
     const { email, password } = req.body;
 
@@ -85,6 +95,50 @@ router.post(
       const error = err as FirebaseAuthError;
       console.error("Error creating a new user:", error);
       res.status(500).json({ error: error.message });
+    }
+  }
+);
+
+router.patch(
+  "/",
+  body().isObject().withMessage("Body is missing or not an object"),
+  body("type")
+    .isIn(["email", "password"])
+    .withMessage("Change type must be 'email' or 'password'"),
+  body("email").isEmail().withMessage("Invalid email"),
+  auth,
+  async (req, res) => {
+    // Update the user's credentials
+    checkValidations(req, res);
+    if (res.writableEnded) return;
+
+    const { type, email } = req.body;
+    const { token } = res.locals;
+
+    if (type === "email") {
+      try {
+        const emailResponse = await changeEmail(email, token);
+        console.log(`Sending verification email to ${emailResponse.email}...`);
+        res.json({
+          ...emailResponse,
+          token,
+        });
+      } catch (error) {
+        handleFirebaseRestError("Failed to change the email", error, res);
+      }
+    } else {
+      try {
+        const emailResponse = await resetPassword(email);
+        console.log(
+          `Sending password reset email to ${emailResponse.email}...`
+        );
+        res.json({
+          ...emailResponse,
+          token,
+        });
+      } catch (error) {
+        handleFirebaseRestError("Failed to reset the password", error, res);
+      }
     }
   }
 );
@@ -115,14 +169,8 @@ router.post(
     .isLength({ min: 8 })
     .withMessage("Password must be at least 8 characters long"),
   async (req, res) => {
-    const validationErrors = validationResult(req);
-    if (!validationErrors.isEmpty()) {
-      const errorMessages = validationErrors.array().map((error) => error.msg);
-      res
-        .status(400)
-        .json({ error: `Invalid request: ${errorMessages.join(" | ")}` });
-      return;
-    }
+    checkValidations(req, res);
+    if (res.writableEnded) return;
 
     const { email, password } = req.body;
 

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -6,12 +6,7 @@ import { FirebaseAuthError } from "firebase-admin/auth";
 
 import FirebaseAdmin from "../utils/auth/admin";
 import auth from "../middleware/auth";
-import {
-  changeEmail,
-  login,
-  resetPassword,
-  verifyEmail,
-} from "../utils/auth/api";
+import FirebaseApi from "../utils/auth/api";
 import { isFirebaseRestError } from "../types/firebase/FirebaseRestError";
 import { handleAxiosError } from "../utils/api";
 import { getChef, saveRefreshToken } from "../utils/db";
@@ -117,7 +112,10 @@ router.patch(
 
     if (type === "email") {
       try {
-        const emailResponse = await changeEmail(email, token);
+        const emailResponse = await FirebaseApi.instance.changeEmail(
+          email,
+          token
+        );
         console.log(`Sending verification email to ${emailResponse.email}...`);
         res.json({
           ...emailResponse,
@@ -128,7 +126,7 @@ router.patch(
       }
     } else {
       try {
-        const emailResponse = await resetPassword(email);
+        const emailResponse = await FirebaseApi.instance.resetPassword(email);
         console.log(
           `Sending password reset email to ${emailResponse.email}...`
         );
@@ -148,7 +146,7 @@ router.post("/verify", auth, async (_req, res) => {
   const { token } = res.locals;
 
   try {
-    const emailResponse = await verifyEmail(token);
+    const emailResponse = await FirebaseApi.instance.verifyEmail(token);
     console.log(`Sending verification email to ${emailResponse.email}...`);
     res.json({
       ...emailResponse,
@@ -175,10 +173,8 @@ router.post(
     const { email, password } = req.body;
 
     try {
-      const { localId, idToken, registered, refreshToken } = await login(
-        email,
-        password
-      );
+      const { localId, idToken, registered, refreshToken } =
+        await FirebaseApi.instance.login(email, password);
       await saveRefreshToken(localId, refreshToken);
 
       res.json({

--- a/tests/object.test.ts
+++ b/tests/object.test.ts
@@ -100,4 +100,18 @@ describe("filterObject", () => {
 
     expect(Object.keys(filteredObject).sort()).toEqual(["b"]);
   });
+
+  it("includes keys with nullable types", () => {
+    const keys = ["a", "d", "e", "f", "g"];
+    const objectWithOptionalKeys = {
+      ...object,
+      d: undefined,
+      e: null,
+      f: 0,
+      g: [],
+    };
+    const filteredObject = filterObject(objectWithOptionalKeys, keys);
+
+    expect(Object.keys(filteredObject).sort()).toEqual(keys);
+  });
 });

--- a/types/client/Chef.ts
+++ b/types/client/Chef.ts
@@ -1,6 +1,5 @@
 type Chef = {
   _id: string; // Firebase UID
-  email: string;
   refreshToken: string | null;
   ratings: Record<string, number>;
   recentRecipes: string[];

--- a/types/firebase/OobCodeResponse.ts
+++ b/types/firebase/OobCodeResponse.ts
@@ -1,0 +1,6 @@
+type OobCodeResponse = {
+  kind: string;
+  email: string;
+};
+
+export default OobCodeResponse;

--- a/types/firebase/VerifyEmailResponse.ts
+++ b/types/firebase/VerifyEmailResponse.ts
@@ -1,6 +1,0 @@
-type VerifyEmailResponse = {
-  kind: string;
-  email: string;
-};
-
-export default VerifyEmailResponse;

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -41,7 +41,7 @@ export default class FirebaseAdmin {
       disabled: false,
     });
     const uid = userRecord.uid;
-    await createChef(userRecord.uid, email);
+    await createChef(userRecord.uid);
     // Save the refresh token after creating a new chef doc
     const idToken = await this.getIdToken(uid);
 

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -4,7 +4,7 @@ import { getAuth, UserRecord } from "firebase-admin/auth";
 
 import { createChef, deleteChef, saveRefreshToken } from "../db";
 import UserInfoResponse from "../../types/firebase/UserInfoResponse";
-import { exchangeCustomToken } from "./api";
+import FirebaseApi from "./api";
 
 export default class FirebaseAdmin {
   private static _instance: FirebaseAdmin; // singleton
@@ -62,7 +62,8 @@ export default class FirebaseAdmin {
   async getIdToken(uid: string): Promise<string> {
     const auth = getAuth();
     const customToken = await auth.createCustomToken(uid);
-    const { idToken, refreshToken } = await exchangeCustomToken(customToken);
+    const { idToken, refreshToken } =
+      await FirebaseApi.instance.exchangeCustomToken(customToken);
     await saveRefreshToken(uid, refreshToken);
     return idToken;
   }

--- a/utils/auth/api.ts
+++ b/utils/auth/api.ts
@@ -1,130 +1,148 @@
-import axios from "axios";
+import axios, { AxiosInstance } from "axios";
 
 import OobCodeResponse from "../../types/firebase/OobCodeResponse";
 import FirebaseTokenResponse from "../../types/firebase/FirebaseTokenResponse";
 import FirebaseTokenExchangeResponse from "../../types/firebase/FirebaseTokenExchangeResponse";
 import FirebaseLoginResponse from "../../types/firebase/FirebaseLoginResponse";
 
-const idApi = axios.create({
-  baseURL: "https://identitytoolkit.googleapis.com/v1",
-  params: {
-    key: process.env.WEB_API_KEY,
-  },
-  signal: new AbortController().signal,
-});
+export default class FirebaseApi {
+  private static _instance: FirebaseApi;
+  private idApi: AxiosInstance;
+  private secureApi: AxiosInstance;
 
-const secureApi = axios.create({
-  baseURL: "https://securetoken.googleapis.com/v1",
-  params: {
-    key: process.env.WEB_API_KEY,
-  },
-  signal: new AbortController().signal,
-});
+  private constructor() {
+    this.idApi = axios.create({
+      baseURL: "https://identitytoolkit.googleapis.com/v1",
+      params: {
+        key: process.env.WEB_API_KEY,
+      },
+      signal: new AbortController().signal,
+    });
 
-/**
- * Exchange a custom token for an ID & refresh token
- * @param customToken a custom token created by the Firebase Admin SDK
- * @throws `FirebaseRestError` if an error occurred
- * @returns an ID & refresh token
- */
-export const exchangeCustomToken = async (
-  customToken: string
-): Promise<FirebaseTokenExchangeResponse> => {
-  const response = await idApi.post<FirebaseTokenExchangeResponse>(
-    "/accounts:signInWithCustomToken",
-    {
-      token: customToken,
-      returnSecureToken: true,
+    this.secureApi = axios.create({
+      baseURL: "https://securetoken.googleapis.com/v1",
+      params: {
+        key: process.env.WEB_API_KEY,
+      },
+      signal: new AbortController().signal,
+    });
+  }
+
+  static get instance() {
+    if (this._instance === undefined) {
+      this._instance = new this();
     }
-  );
-  return response.data;
-};
 
-/**
- * Login the user using their email and password
- * @param email the user's email
- * @param password the user's password
- * @throws `FirebaseRestError` if an error occurred
- * @returns the user's UID, tokens, and other information
- */
-export const login = async (
-  email: string,
-  password: string
-): Promise<FirebaseLoginResponse> => {
-  const response = await idApi.post<FirebaseLoginResponse>(
-    "/accounts:signInWithPassword",
-    {
-      email,
-      password,
-      returnSecureToken: true,
-    }
-  );
-  return response.data;
-};
+    return this._instance;
+  }
 
-/**
- * Send a verification email to the user
- * @param token the Firebase ID token
- * @throws `FirebaseRestError` if an error occurred
- * @returns the email address to verify
- */
-export const verifyEmail = async (token: string): Promise<OobCodeResponse> => {
-  // OOB = out-of-band
-  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
-    requestType: "VERIFY_EMAIL",
-    idToken: token,
-  });
-  return response.data;
-};
+  /**
+   * Exchange a custom token for an ID & refresh token
+   * @param customToken a custom token created by the Firebase Admin SDK
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns an ID & refresh token
+   */
+  async exchangeCustomToken(
+    customToken: string
+  ): Promise<FirebaseTokenExchangeResponse> {
+    const response = await this.idApi.post<FirebaseTokenExchangeResponse>(
+      "/accounts:signInWithCustomToken",
+      {
+        token: customToken,
+        returnSecureToken: true,
+      }
+    );
+    return response.data;
+  }
 
-/**
- * Send an email to reset the user's password
- * @param email the email address to send the notification
- * @throws `FirebaseRestError` if an error occurred
- * @returns the email address sent to
- */
-export const resetPassword = async (
-  email: string
-): Promise<OobCodeResponse> => {
-  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
-    requestType: "PASSWORD_RESET",
-    email,
-  });
-  return response.data;
-};
+  /**
+   * Login the user using their email and password
+   * @param email the user's email
+   * @param password the user's password
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns the user's UID, tokens, and other information
+   */
+  async login(email: string, password: string): Promise<FirebaseLoginResponse> {
+    const response = await this.idApi.post<FirebaseLoginResponse>(
+      "/accounts:signInWithPassword",
+      {
+        email,
+        password,
+        returnSecureToken: true,
+      }
+    );
+    return response.data;
+  }
 
-/**
- * Send an email to confirm a new email address
- * @param email the new email address to verify
- * @param token the Firebase ID token
- * @throws `FirebaseRestError` if an error occurred
- * @returns the email address to verify
- */
-export const changeEmail = async (
-  email: string,
-  token: string
-): Promise<OobCodeResponse> => {
-  // Documented in Identity Platform, but not in Firebase
-  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
-    requestType: "VERIFY_AND_CHANGE_EMAIL",
-    newEmail: email,
-    idToken: token,
-  });
-  return response.data;
-};
+  /**
+   * Send a verification email to the user
+   * @param token the Firebase ID token
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns the email address to verify
+   */
+  async verifyEmail(token: string): Promise<OobCodeResponse> {
+    // OOB = out-of-band
+    const response = await this.idApi.post<OobCodeResponse>(
+      "/accounts:sendOobCode",
+      {
+        requestType: "VERIFY_EMAIL",
+        idToken: token,
+      }
+    );
+    return response.data;
+  }
 
-/**
- * Get a new ID token using the refresh token
- * @param refreshToken the refresh token
- * @throws `FirebaseRestError` if an error occurred
- * @returns new token information
- */
-export const refreshIdToken = async (
-  refreshToken: string
-): Promise<FirebaseTokenResponse> => {
-  const response = await secureApi.post<FirebaseTokenResponse>("/token", {
-    grant_type: "refresh_token",
-    refresh_token: refreshToken,
-  });
-  return response.data;
-};
+  /**
+   * Send an email to reset the user's password
+   * @param email the email address to send the notification
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns the email address sent to
+   */
+  async resetPassword(email: string): Promise<OobCodeResponse> {
+    const response = await this.idApi.post<OobCodeResponse>(
+      "/accounts:sendOobCode",
+      {
+        requestType: "PASSWORD_RESET",
+        email,
+      }
+    );
+    return response.data;
+  }
+
+  /**
+   * Send an email to confirm a new email address
+   * @param email the new email address to verify
+   * @param token the Firebase ID token
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns the email address to verify
+   */
+  async changeEmail(email: string, token: string): Promise<OobCodeResponse> {
+    // Documented in Identity Platform, but not in Firebase
+    const response = await this.idApi.post<OobCodeResponse>(
+      "/accounts:sendOobCode",
+      {
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+        newEmail: email,
+        idToken: token,
+      }
+    );
+    return response.data;
+  }
+
+  /**
+   * Get a new ID token using the refresh token
+   * @param refreshToken the refresh token
+   * @throws `FirebaseRestError` if an error occurred
+   * @returns new token information
+   */
+  async refreshIdToken(refreshToken: string): Promise<FirebaseTokenResponse> {
+    const response = await this.secureApi.post<FirebaseTokenResponse>(
+      "/token",
+      {
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }
+    );
+    return response.data;
+  }
+}

--- a/utils/auth/api.ts
+++ b/utils/auth/api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import VerifyEmailResponse from "../../types/firebase/VerifyEmailResponse";
+import OobCodeResponse from "../../types/firebase/OobCodeResponse";
 import FirebaseTokenResponse from "../../types/firebase/FirebaseTokenResponse";
 import FirebaseTokenExchangeResponse from "../../types/firebase/FirebaseTokenExchangeResponse";
 import FirebaseLoginResponse from "../../types/firebase/FirebaseLoginResponse";
@@ -68,17 +68,48 @@ export const login = async (
  * @throws `FirebaseRestError` if an error occurred
  * @returns the email address to verify
  */
-export const verifyEmail = async (
-  token: string
-): Promise<VerifyEmailResponse> => {
+export const verifyEmail = async (token: string): Promise<OobCodeResponse> => {
   // OOB = out-of-band
-  const response = await idApi.post<VerifyEmailResponse>(
-    "/accounts:sendOobCode",
-    {
-      requestType: "VERIFY_EMAIL",
-      idToken: token,
-    }
-  );
+  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
+    requestType: "VERIFY_EMAIL",
+    idToken: token,
+  });
+  return response.data;
+};
+
+/**
+ * Send an email to reset the user's password
+ * @param email the email address to send the notification
+ * @throws `FirebaseRestError` if an error occurred
+ * @returns the email address sent to
+ */
+export const resetPassword = async (
+  email: string
+): Promise<OobCodeResponse> => {
+  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
+    requestType: "PASSWORD_RESET",
+    email,
+  });
+  return response.data;
+};
+
+/**
+ * Send an email to confirm a new email address
+ * @param email the new email address to verify
+ * @param token the Firebase ID token
+ * @throws `FirebaseRestError` if an error occurred
+ * @returns the email address to verify
+ */
+export const changeEmail = async (
+  email: string,
+  token: string
+): Promise<OobCodeResponse> => {
+  // Documented in Identity Platform, but not in Firebase
+  const response = await idApi.post<OobCodeResponse>("/accounts:sendOobCode", {
+    requestType: "VERIFY_AND_CHANGE_EMAIL",
+    newEmail: email,
+    idToken: token,
+  });
   return response.data;
 };
 

--- a/utils/db/chefs.ts
+++ b/utils/db/chefs.ts
@@ -7,12 +7,10 @@ import Encryptor from "../crypto";
 /**
  * Create a new chef in the DB
  * @param uid the UID of the chef
- * @param email the email of the chef
  */
-export const createChef = async (uid: string, email: string) => {
+export const createChef = async (uid: string) => {
   const chef: Chef = {
     _id: uid,
-    email,
     refreshToken: null,
     ratings: {},
     recentRecipes: [],

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -35,7 +35,7 @@ export const isEmptyObject = (object: Record<string, unknown>) => {
  * @returns a new object only containing the keys passed
  */
 export const filterObject = <T extends string>(
-  object: { [key in T]: unknown },
+  object: { [key in T]?: unknown },
   keys: T[]
 ): typeof object => {
   return Object.fromEntries(


### PR DESCRIPTION
## PATCH /api/chefs

Requires auth for changing emails, but not for changing passwords. Sample request bodies:

### Change Email
```json
{
    "type": "email",
    "email": "test@email.com"
}
```

<img width="281" alt="Screenshot 2024-10-08 190047" src="https://github.com/user-attachments/assets/027a20a7-db8a-4938-b52a-ea662a551dda">
<img width="592" alt="image" src="https://github.com/user-attachments/assets/614f7dc8-955d-4036-abf9-579b2fe472b2">

### Reset Password
```json
{
    "type": "password",
    "email": "test@email.com"
}
```

<img width="278" alt="374743973-cc939126-ac3e-4559-ac47-e3f24980cb6b" src="https://github.com/user-attachments/assets/1a3dc4a4-54f1-4092-baf8-b382e8b8aa37">
<img width="275" alt="image" src="https://github.com/user-attachments/assets/2c077000-6818-4831-ac5a-0ed455d1179b">

Sample response body:

```json
{
    "kind": "identitytoolkit#GetOobConfirmationCodeResponse",
    "email": "test@email.com",
    "token": "eyJ..."
}
```

These were interesting to work with. Although the admin SDK provides `updateUser`, it's a little too OP. I'd rather have the user confirm that they want to change their email or password before updating on Firebase. Changing the password was straightforward, but I couldn't find anything in the REST API docs for changing the email. However, I noticed the endpoint was the same as the verify email one. I learned that the client SDK has a [verifyBeforeUpdateEmail](https://firebase.google.com/docs/reference/js/auth.md#verifybeforeupdateemail_09d6f11) method, which has an ActionCodeOperation of VERIFY_AND_CHANGE_EMAIL. Through context clues, I figured out that this can be the `requestType` for changing the email. That's when I learned the [Identity Platform docs](https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/sendOobCode?hl=en) are more up-to-date and confirmed my theory. In both cases, an email is sent to verify the operation. Once submitted, these fields are updated automatically on Firebase.

A user should be able to change their password if they forget it, so we shouldn't require an ID token for the endpoint. We can still accept one by giving the user the option on a profile page. This is also where we can provide the option to change their email address.

To avoid syncing email changes, I removed the email field from MongoDB:

<img width="728" alt="image" src="https://github.com/user-attachments/assets/8c0addc2-9b85-45ec-ba47-bbb942317a2b">

This will also ensure greater privacy for users' records. As a result, I updated the GET endpoint to call the admin SDK's `getUser` to return the user's email in the response, with an extra error case.