### PR TITLE
Add endpoint to delete an account

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -119,6 +119,33 @@ paths:
                 emailAlreadyTaken:
                   $ref: "#/components/examples/emailAlreadyTaken"
 
+    delete:
+      summary: Delete an account
+      tags:
+        - chefs
+      security:
+        - bearerAuth: []
+      responses:
+        "204":
+          description: Successfully deleted the account
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                missingToken:
+                  $ref: "#/components/examples/missingToken"
+
+        "500":
+          description: An error occurred while deleting the account
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
   /verify:
     post:
       summary: Verify the chef's account

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -145,6 +145,20 @@ router.patch(
   }
 );
 
+router.delete("/", auth, async (_req, res) => {
+  // Delete the user's account
+  const { uid } = res.locals;
+
+  try {
+    await FirebaseAdmin.instance.deleteUser(uid);
+    res.sendStatus(204);
+  } catch (err) {
+    const error = err as FirebaseAuthError;
+    console.error("Error deleting user:", error);
+    res.status(500).json({ error: error.message });
+  }
+});
+
 router.post("/verify", auth, async (_req, res) => {
   // Send a verification email
   const { token } = res.locals;
@@ -202,20 +216,6 @@ router.post("/logout", auth, async (_req, res) => {
     const error = err as FirebaseAuthError;
     console.error("Error logging out:", error);
     res.status(500).json({ error: error.message });
-  }
-});
-
-router.delete("/:id", async (req, res) => {
-  // Delete the user's account
-  const uid = req.params.id;
-
-  try {
-    await FirebaseAdmin.instance.deleteUser(uid);
-    res.sendStatus(204);
-  } catch (err) {
-    const error = err as FirebaseAuthError;
-    console.error("Error deleting user:", error);
-    res.status(404).json({ error: error.message });
   }
 });
 


### PR DESCRIPTION
## DELETE /api/chefs

No request or response body, requires auth

All the required methods were already implemented in #283. I only changed having the UID in the path to using the auth middleware.

So far this is the distribution between the admin SDK and the REST API:

### Admin SDK
- Create user
- Get user
- Delete user
- Get ID token (by creating a custom token)
- Validate ID token
- Logout (revoke ID & refresh token)

### REST API
- Get ID & refresh token (by signing in with a custom token)
- Login
- Send verification email
- Change email & password
- Refresh ID token

Almost an even split. The admin SDK is used to manage the Firebase user and ID token directly. Whereas the REST API is used to sign in, send verification codes (for relatively high-risk transactions), and refresh tokens.