### PR TITLE
282 add endpoint to update a recipes views rating

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -261,10 +261,10 @@ components:
           additionalProperties:
             type: integer
         recentRecipes:
-          type: array
-          items:
-            type: string
-            description: The ID of a recipe recently viewed
+          type: object
+          description: >-
+            Key-value pairs, where the key is the recipe ID
+            and the value is the timestamp the recipe was last viewed
         favoriteRecipes:
           type: array
           items:

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -338,12 +338,18 @@ components:
     userNotFound:
       value:
         {
-          "error": "Invalid Firebase token provided: Error: There is no user record corresponding to the provided identifier.",
+          "error":
+            "Invalid Firebase token provided: Error: There is no user record corresponding
+            to the provided identifier.",
         }
     missingToken:
       value:
         {
-          "error": "Invalid Firebase token provided: Error: Decoding Firebase ID token failed. Make sure you passed the entire string JWT which represents an ID token. See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to retrieve an ID token.",
+          "error":
+            "Invalid Firebase token provided: Error: Decoding Firebase ID token failed.
+            Make sure you passed the entire string JWT which represents an ID token.
+            See https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on
+            how to retrieve an ID token.",
         }
     invalidCredentials:
       value: { "error": "Failed to login: INVALID_LOGIN_CREDENTIALS" }

--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -267,6 +267,58 @@ paths:
                 nonExistentRecipeId:
                   $ref: "#/components/examples/nonExistentRecipeId"
 
+    patch:
+      summary: >-
+        Update information about a recipe. Some info may require authentication.
+      tags:
+        - recipes
+      security:
+        - {} # no security
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/recipePatch"
+      responses:
+        "200":
+          description: Successfully updated the recipe
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/token"
+
+        "400":
+          description: The request body is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                invalidRecipeId:
+                  $ref: "#/components/examples/invalidRecipeId"
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                userNotFound:
+                  $ref: "#/components/examples/userNotFound"
+
+        "404":
+          description: The recipe or chef couldn't be found
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                nonExistentRecipeId:
+                  $ref: "#/components/examples/nonExistentRecipeId"
+
 components:
   parameters:
     recipeId:
@@ -473,6 +525,43 @@ components:
           description: >
             A base64 token that can be used to paginate additional recipes.
             Only returned if a query was passed.
+        rating:
+          type: number
+          nullable: true
+          minimum: 1
+          maximum: 5
+          description: >-
+            The average rating for the recipe from 1-5 stars, null if no ratings are available
+        views:
+          type: integer
+          minimum: 0
+          description: The total number of views for the recipe
+        likes:
+          type: integer
+          minimum: 0
+          description: The number of chefs that like the recipe
+    recipePatch:
+      type: object
+      properties:
+        rating:
+          type: integer
+          minimum: 1
+          maximum: 5
+          description: The rating to give the recipe, from 1-5 stars, requires auth
+        view:
+          type: boolean
+          description: true if the recipe's view count should be incremented
+        isFavorite:
+          type: boolean
+          description: >-
+            true if the recipe should be added to favorites,
+            false if it should be removed, requires auth
+    token:
+      type: object
+      properties:
+        token:
+          type: string
+          description: The ID token for the chef
 
   examples:
     invalidFilter:
@@ -491,3 +580,10 @@ components:
         }
     nonExistentRecipeId:
       value: { "error": "A recipe with the id 0 does not exist." }
+    userNotFound:
+      value:
+        {
+          "error":
+            "Invalid Firebase token provided: Error: There is no user record corresponding
+            to the provided identifier.",
+        }

--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -319,6 +319,13 @@ paths:
                 nonExistentRecipeId:
                   $ref: "#/components/examples/nonExistentRecipeId"
 
+        "500":
+          description: An unknown error occurred while updating the recipe or chef
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
 components:
   parameters:
     recipeId:
@@ -561,7 +568,7 @@ components:
       properties:
         token:
           type: string
-          description: The ID token for the chef
+          description: The ID token for the chef, if one was passed
 
   examples:
     invalidFilter:

--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -269,7 +269,7 @@ paths:
 
     patch:
       summary: >-
-        Update information about a recipe. Some info may require authentication.
+        Update information about a recipe. Some fields require authentication.
       tags:
         - recipes
       security:
@@ -320,7 +320,7 @@ paths:
                   $ref: "#/components/examples/nonExistentRecipeId"
 
         "500":
-          description: An unknown error occurred while updating the recipe or chef
+          description: An error occurred while updating the recipe or chef
           content:
             application/json:
               schema:

--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -525,21 +525,21 @@ components:
           description: >
             A base64 token that can be used to paginate additional recipes.
             Only returned if a query was passed.
-        rating:
+        averageRating:
           type: number
           nullable: true
           minimum: 1
           maximum: 5
           description: >-
             The average rating for the recipe from 1-5 stars, null if no ratings are available
+        totalRatings:
+          type: number
+          minimum: 0
+          description: The total number of ratings for the recipe
         views:
           type: integer
           minimum: 0
           description: The total number of views for the recipe
-        likes:
-          type: integer
-          minimum: 0
-          description: The number of chefs that like the recipe
     recipePatch:
       type: object
       properties:

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -25,9 +25,14 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
     ? authHeader.split("Bearer ")[1]
     : authHeader;
   const isChangingPassword =
-    req.url === "/" && req.method === "PATCH" && req.body.type === "password";
+    req.originalUrl === "/api/chefs" &&
+    req.method === "PATCH" &&
+    req.body?.type === "password";
   const isViewingRecipe =
-    req.url === "/:id" && req.method === "PATCH" && req.body.view === true;
+    req.originalUrl.startsWith("/api/recipes/") &&
+    req.params.id !== undefined &&
+    req.method === "PATCH" &&
+    typeof req.body?.view === "boolean";
 
   if (token === undefined) {
     // Skip validation for certain requests

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -26,10 +26,12 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
     : authHeader;
   const isChangingPassword =
     req.url === "/" && req.method === "PATCH" && req.body.type === "password";
+  const isViewingRecipe =
+    req.url === "/:id" && req.method === "PATCH" && req.body.view === true;
 
   if (token === undefined) {
-    // Skip validation if changing passwords
-    if (isChangingPassword) {
+    // Skip validation for certain requests
+    if (isChangingPassword || isViewingRecipe) {
       next();
     } else {
       res

--- a/models/ChefModel.ts
+++ b/models/ChefModel.ts
@@ -5,7 +5,7 @@ const ChefSchema = new Schema<Chef>({
   _id: { type: String, required: true },
   refreshToken: { type: String, default: null },
   ratings: { type: Map, of: Number, required: true },
-  recentRecipes: { type: [String], required: true },
+  recentRecipes: { type: Map, of: Date, required: true },
   favoriteRecipes: { type: [String], required: true },
 });
 

--- a/models/RecipeModel.ts
+++ b/models/RecipeModel.ts
@@ -1,46 +1,67 @@
 import { Schema, model } from "mongoose";
 import Recipe, { CUISINES, MEAL_TYPES } from "../types/client/Recipe";
 
-const NutritionSchema = new Schema<Recipe["nutrients"][number]>({
-  name: { type: String, required: true },
-  amount: { type: Number, required: true },
-  unit: { type: String, required: true },
-});
+// Allow empty strings as part of the required validator
+Schema.Types.String.checkRequired((v) => typeof v === "string");
 
-const IngredientSchema = new Schema<Recipe["ingredients"][number]>({
-  id: { type: Number, required: true },
-  name: { type: String, required: true },
-  amount: { type: Number, required: true },
-  unit: { type: String, required: true },
-});
+const NutritionSchema = new Schema<Recipe["nutrients"][number]>(
+  {
+    name: { type: String, required: true },
+    amount: { type: Number, required: true },
+    unit: { type: String, required: true },
+  },
+  { _id: false } // don't add _id to every object
+);
+
+const IngredientSchema = new Schema<Recipe["ingredients"][number]>(
+  {
+    id: { type: Number, required: true },
+    name: { type: String, required: true },
+    amount: { type: Number, required: true },
+    unit: { type: String, required: true },
+  },
+  { _id: false }
+);
 
 const StepIngredientSchema = new Schema<
   Recipe["instructions"][number]["steps"][number]["ingredients"][number]
->({
-  id: { type: Number, required: true },
-  name: { type: String, required: true },
-  image: { type: String, required: true },
-});
+>(
+  {
+    id: { type: Number, required: true },
+    name: { type: String, required: true },
+    image: { type: String, required: true },
+  },
+  { _id: false }
+);
 
 const StepEquipmentSchema = new Schema<
   Recipe["instructions"][number]["steps"][number]["equipment"][number]
->({
-  id: { type: Number, required: true },
-  name: { type: String, required: true },
-  image: { type: String, required: true },
-});
+>(
+  {
+    id: { type: Number, required: true },
+    name: { type: String, required: true },
+    image: { type: String, required: true },
+  },
+  { _id: false }
+);
 
-const StepSchema = new Schema<Recipe["instructions"][number]["steps"][number]>({
-  number: { type: Number, required: true },
-  step: { type: String, required: true },
-  ingredients: { type: [StepIngredientSchema], required: true },
-  equipment: { type: [StepEquipmentSchema], required: true },
-});
+const StepSchema = new Schema<Recipe["instructions"][number]["steps"][number]>(
+  {
+    number: { type: Number, required: true },
+    step: { type: String, required: true },
+    ingredients: { type: [StepIngredientSchema], required: true },
+    equipment: { type: [StepEquipmentSchema], required: true },
+  },
+  { _id: false }
+);
 
-const InstructionSchema = new Schema<Recipe["instructions"][number]>({
-  name: { type: String, required: true },
-  steps: { type: [StepSchema], required: true },
-});
+const InstructionSchema = new Schema<Recipe["instructions"][number]>(
+  {
+    name: { type: String, required: true },
+    steps: { type: [StepSchema], required: true },
+  },
+  { _id: false }
+);
 
 const RecipeSchema = new Schema<Recipe>({
   id: { type: Number, required: true },

--- a/models/RecipeModel.ts
+++ b/models/RecipeModel.ts
@@ -66,6 +66,9 @@ const RecipeSchema = new Schema<Recipe>({
   nutrients: { type: [NutritionSchema], required: true },
   ingredients: { type: [IngredientSchema], required: true },
   instructions: { type: [InstructionSchema], required: true },
+  averageRating: { type: Number, default: null },
+  totalRatings: { type: Number, default: 0 },
+  views: { type: Number, default: 0 },
 });
 
 export default model("recipe", RecipeSchema);

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,6 +43,10 @@ components:
       $ref: "./docs/recipes.yaml#/components/schemas/recipes"
     recipe:
       $ref: "./docs/recipes.yaml#/components/schemas/recipe"
+    recipePatch:
+      $ref: "./docs/recipes.yaml#/components/schemas/recipePatch"
+    token:
+      $ref: "./docs/recipes.yaml#/components/schemas/token"
     error:
       type: object
       properties:

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -13,7 +13,7 @@ import {
   sanitizeEnumArray,
   sanitizeNumber,
 } from "../utils/recipeUtils";
-import { isNumeric } from "../utils/string";
+import { isInteger, isNumeric } from "../utils/string";
 import spoonacularApi, { handleAxiosError } from "../utils/api";
 import {
   fetchRecipe,
@@ -30,6 +30,7 @@ import {
 } from "../types/client/Recipe";
 import auth from "../middleware/auth";
 import RecipePatch from "../types/client/RecipePatch";
+import { isObject } from "../utils/object";
 
 const badRequestError = (res: Response, error: string) => {
   res.status(400).json({ error });
@@ -212,10 +213,34 @@ router.patch("/:id", auth, async (req, res) => {
   // Update info for both the recipe and chef
   const { token, uid } = res.locals;
   const { id } = req.params;
-  const body = req.body as RecipePatch;
+  const body = req.body as RecipePatch | undefined;
 
   if (!isNumeric(id)) {
     res.status(400).json({ error: "The recipe ID must be numeric" });
+    return;
+  }
+
+  if (body === undefined || !isObject(body)) {
+    res.status(400).json({
+      error: "One of 'rating', 'view', or 'isFavorite' must be provided",
+    });
+    return;
+  }
+  if (
+    body.rating !== undefined &&
+    (!isInteger(body.rating) || body.rating < 1 || body.rating > 5)
+  ) {
+    res
+      .status(400)
+      .json({ error: "The rating must be a whole number between 1 and 5" });
+    return;
+  }
+  if (body.view !== undefined && typeof body.view !== "boolean") {
+    res.status(400).json({ error: "'view' must be true or false" });
+    return;
+  }
+  if (body.isFavorite !== undefined && typeof body.isFavorite !== "boolean") {
+    res.status(400).json({ error: "'isFavorite' must be true or false" });
     return;
   }
 

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -258,12 +258,8 @@ router.patch("/:id", auth, async (req, res) => {
   let oldRating = undefined;
 
   if (isAuthenticated) {
-    const [newDidUpdateRating, updateChefError] = await updateChef(
-      uid,
-      id,
-      body
-    );
-    oldRating = newDidUpdateRating;
+    const [newOldRating, updateChefError] = await updateChef(uid, id, body);
+    oldRating = newOldRating;
 
     if (updateChefError !== undefined) {
       res.status(updateChefError.code).json({ error: updateChefError.message });

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -64,6 +64,23 @@ describe("auth-middleware", () => {
     expect(mockResponse.locals.token).not.toBeDefined();
   });
 
+  it("skips validation if viewing a recipe", async () => {
+    mockValidateToken(true);
+    await auth(
+      mockRequest(undefined, {
+        url: "/:id",
+        method: "PATCH",
+        body: { view: true },
+      }),
+      mockResponse,
+      mockNext
+    );
+
+    expect(mockNext).toHaveBeenCalled();
+    expect(mockResponse.locals.uid).not.toBeDefined();
+    expect(mockResponse.locals.token).not.toBeDefined();
+  });
+
   it("rejects a missing token", async () => {
     mockValidateToken(true);
     await auth(mockRequest(), mockResponse, mockNext);

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -6,6 +6,7 @@ import FirebaseAdmin from "../utils/auth/admin";
 
 const mockRequest = (authorization?: string, req?: object) =>
   ({
+    originalUrl: "/",
     ...req,
     headers: {
       authorization,
@@ -51,7 +52,7 @@ describe("auth-middleware", () => {
     mockValidateToken(true);
     await auth(
       mockRequest(undefined, {
-        url: "/",
+        originalUrl: "/api/chefs",
         method: "PATCH",
         body: { type: "password", email: "test@email.com" },
       }),
@@ -68,7 +69,8 @@ describe("auth-middleware", () => {
     mockValidateToken(true);
     await auth(
       mockRequest(undefined, {
-        url: "/:id",
+        originalUrl: "/api/recipes/:id",
+        params: { id: 0 },
         method: "PATCH",
         body: { view: true },
       }),

--- a/tests/number.test.ts
+++ b/tests/number.test.ts
@@ -1,0 +1,23 @@
+import { round } from "../utils/number";
+
+describe("round", () => {
+  it.each([
+    [3.141592, 0, 3],
+    [3.141592, 1, 3.1],
+    [3.141592, 2, 3.14],
+    [3.141592, 3, 3.142],
+    [3.141592, 4, 3.1416],
+  ])("rounds %d to %d decimal place(s)", (num, places, roundedNum) => {
+    expect(round(num, places)).toBe(roundedNum);
+  });
+
+  it.each([
+    [623305.1, 0, 623305],
+    [623305.1, -1, 623310],
+    [623305.1, -2, 623300],
+    [623305.1, -3, 623000],
+    [623305.1, -4, 620000],
+  ])("rounds %d to %d decimal place(s)", (num, places, roundedNum) => {
+    expect(round(num, places)).toBe(roundedNum);
+  });
+});

--- a/tests/recipeUtils.test.ts
+++ b/tests/recipeUtils.test.ts
@@ -4560,4 +4560,7 @@ export const expectedRecipe: Omit<Recipe, "_id"> = {
       ],
     },
   ],
+  averageRating: null,
+  totalRatings: 0,
+  views: 0,
 };

--- a/tests/string.test.ts
+++ b/tests/string.test.ts
@@ -1,4 +1,4 @@
-import { isNumeric } from "../utils/string";
+import { isInteger, isNumeric } from "../utils/string";
 
 describe("isNumeric", () => {
   it.each([
@@ -15,7 +15,7 @@ describe("isNumeric", () => {
     -1,
     -32.1,
     "0x1",
-  ])("passes all positive cases", (num: number | string) => {
+  ])("passes positive case: %s", (num: number | string) => {
     // Given a set of inputs that resemble numbers
     // When passed to isNumeric
     // Then they should all return true
@@ -34,10 +34,44 @@ describe("isNumeric", () => {
     undefined,
     [],
     NaN,
-  ])("passes all negative cases", (num: unknown) => {
+  ])("passes negative case: %s", (num: unknown) => {
     // Given a set of inputs that don't resemble numbers
     // When passed to isNumeric
     // Then they should all return false
     expect(isNumeric(num as number | string)).toBe(false);
+  });
+});
+
+describe("isInteger", () => {
+  it.each([0, 1, 1234567890, "1234567890", "0", "1", "-1", -1, "0x1"])(
+    "passes positive case: %s",
+    (num: number | string) => {
+      // Given a set of inputs that resemble integers
+      // When passed to isInteger
+      // Then they should all return true
+      expect(isInteger(num)).toBe(true);
+    }
+  );
+
+  it.each([
+    "1.1",
+    "-1.2354",
+    -32.1,
+    true,
+    false,
+    "1..1",
+    "1,1",
+    "-32.1.12",
+    "",
+    "   ",
+    null,
+    undefined,
+    [],
+    NaN,
+  ])("passes negative case: %s", (num: unknown) => {
+    // Given a set of inputs that don't resemble integers
+    // When passed to isInteger
+    // Then they should all return false
+    expect(isInteger(num as number | string)).toBe(false);
   });
 });

--- a/types/client/Chef.ts
+++ b/types/client/Chef.ts
@@ -2,7 +2,7 @@ type Chef = {
   _id: string; // Firebase UID
   refreshToken: string | null;
   ratings: Record<string, number>;
-  recentRecipes: string[];
+  recentRecipes: Record<string, Date>;
   favoriteRecipes: string[];
 };
 

--- a/types/client/Chef.ts
+++ b/types/client/Chef.ts
@@ -1,8 +1,8 @@
 type Chef = {
   _id: string; // Firebase UID
   refreshToken: string | null;
-  ratings: Record<string, number>;
-  recentRecipes: Record<string, Date>;
+  ratings: Map<string, number>;
+  recentRecipes: Map<string, Date>;
   favoriteRecipes: string[];
 };
 

--- a/types/client/Recipe.ts
+++ b/types/client/Recipe.ts
@@ -133,6 +133,9 @@ type Recipe = {
     }[];
   }[];
   token?: string; // searchSequenceToken for pagination
+  averageRating: number | null;
+  totalRatings: number;
+  views: number;
 };
 
 export default Recipe;

--- a/types/client/RecipePatch.ts
+++ b/types/client/RecipePatch.ts
@@ -1,0 +1,7 @@
+type RecipePatch = {
+  rating?: number;
+  view?: boolean;
+  isFavorite?: boolean;
+};
+
+export default RecipePatch;

--- a/utils/db/chefs.ts
+++ b/utils/db/chefs.ts
@@ -3,6 +3,7 @@ import { FilterQuery, UpdateQuery } from "mongoose";
 import ChefModel from "../../models/ChefModel";
 import Chef from "../../types/client/Chef";
 import Encryptor from "../crypto";
+import RecipePatch from "../../types/client/RecipePatch";
 
 /**
  * Create a new chef in the DB
@@ -13,7 +14,7 @@ export const createChef = async (uid: string) => {
     _id: uid,
     refreshToken: null,
     ratings: {},
-    recentRecipes: [],
+    recentRecipes: {},
     favoriteRecipes: [],
   };
 
@@ -37,6 +38,66 @@ export const getChef = async (uid: string): Promise<Chef | null> => {
   } catch (error) {
     console.error("Failed to find chef", `${uid}:`, error);
     return null;
+  }
+};
+
+/**
+ * Update recipe information pertaining to a chef
+ * @param uid the UID of the chef
+ * @param id the ID of the recipe
+ * @param body information to update for the chef
+ */
+export const updateChef = async (
+  uid: string,
+  id: string,
+  body: RecipePatch
+) => {
+  const { rating, view, isFavorite } = body;
+
+  try {
+    const doc = await ChefModel.findOne({ _id: uid }).exec();
+    if (doc === null) {
+      console.warn(`Chef with ID ${uid} not found`);
+      return;
+    }
+
+    if (rating !== undefined) {
+      doc.ratings[id] = rating;
+    }
+    if (view === true) {
+      doc.recentRecipes[id] = new Date();
+    }
+    if (isFavorite !== undefined) {
+      const favoriteRecipesSet = new Set(doc.favoriteRecipes);
+
+      if (isFavorite) {
+        favoriteRecipesSet.add(id);
+      } else {
+        favoriteRecipesSet.delete(id);
+      }
+
+      doc.favoriteRecipes = Array.from(favoriteRecipesSet);
+    }
+
+    await doc.save();
+  } catch (error) {
+    console.error("Failed to update chef", `${uid}`, error);
+  }
+};
+
+/**
+ * Delete a chef from the DB
+ * @param uid the UID of the chef
+ */
+export const deleteChef = async (uid: string) => {
+  const query = { _id: uid };
+
+  try {
+    const result = await ChefModel.deleteOne(query).exec();
+    console.log(`Deleted ${result.deletedCount} chef document`); // should be just 1
+  } catch (error) {
+    // Prevent format string injections from tainting the logs
+    console.error("Failed to delete chef", `${uid}:`, error);
   }
 };
 
@@ -80,21 +141,5 @@ export const getRefreshToken = async (uid: string): Promise<string | null> => {
   } catch (error) {
     console.error(`Failed to get the refresh token for chef ${uid}:`, error);
     return null;
-  }
-};
-
-/**
- * Delete a chef from the DB
- * @param uid the UID of the chef
- */
-export const deleteChef = async (uid: string) => {
-  const query = { _id: uid };
-
-  try {
-    const result = await ChefModel.deleteOne(query).exec();
-    console.log(`Deleted ${result.deletedCount} chef document`); // should be just 1
-  } catch (error) {
-    // Prevent format string injections from tainting the logs
-    console.error("Failed to delete chef", `${uid}:`, error);
   }
 };

--- a/utils/db/chefs.ts
+++ b/utils/db/chefs.ts
@@ -1,4 +1,4 @@
-import { FilterQuery, UpdateQuery } from "mongoose";
+import { FilterQuery, FlattenMaps, UpdateQuery } from "mongoose";
 
 import ChefModel from "../../models/ChefModel";
 import Chef from "../../types/client/Chef";
@@ -13,8 +13,8 @@ export const createChef = async (uid: string) => {
   const chef: Chef = {
     _id: uid,
     refreshToken: null,
-    ratings: {},
-    recentRecipes: {},
+    ratings: new Map(),
+    recentRecipes: new Map(),
     favoriteRecipes: [],
   };
 
@@ -31,7 +31,9 @@ export const createChef = async (uid: string) => {
  * @param uid the UID of the chef
  * @returns the chef's document, or `null` if the chef couldn't be found
  */
-export const getChef = async (uid: string): Promise<Chef | null> => {
+export const getChef = async (
+  uid: string
+): Promise<FlattenMaps<Chef> | null> => {
   try {
     // Return a POJO instead of a Document so filterObject works
     return await ChefModel.findOne({ _id: uid }).lean().exec();
@@ -62,10 +64,10 @@ export const updateChef = async (
     }
 
     if (rating !== undefined) {
-      doc.ratings[id] = rating;
+      doc.ratings.set(id, rating);
     }
     if (view === true) {
-      doc.recentRecipes[id] = new Date();
+      doc.recentRecipes.set(id, new Date());
     }
     if (isFavorite !== undefined) {
       const favoriteRecipesSet = new Set(doc.favoriteRecipes);

--- a/utils/number.ts
+++ b/utils/number.ts
@@ -1,0 +1,12 @@
+// Helper methods for numbers
+
+/**
+ * Round a number to the specified number of decimal places
+ * @param num the number to round
+ * @param places the number of decimals places to round to
+ * @returns the rounded number
+ */
+export const round = (num: number, places: number): number => {
+  const shift = 10 ** places;
+  return Math.round(num * shift) / shift;
+};

--- a/utils/recipeUtils.ts
+++ b/utils/recipeUtils.ts
@@ -280,6 +280,9 @@ export const createClientResponse = async (
         })),
       })),
     })),
+    averageRating: null,
+    totalRatings: 0,
+    views: 0,
   };
 
   return resJson;

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -10,3 +10,11 @@
 export const isNumeric = (num: number | string): boolean =>
   (typeof num === "number" || (typeof num === "string" && num.trim() !== "")) &&
   !isNaN(num as number);
+
+/**
+ * Check if the input can be parsed as an integer
+ * @param num the number or string to check
+ * @returns true if `num` can be parsed as an integer, false otherwise
+ */
+export const isInteger = (num: number | string): boolean =>
+  isNumeric(num) && Number.isInteger(Number(num));


### PR DESCRIPTION
## PATCH /api/recipes/:id

Sample request body:

```json
{
    "rating": 5,
    "view": true,
    "isFavorite": true
}
```

Updating the view count doesn't require auth. Everything else does.

Sample response body:

```json
{
    "token": "eyJ..."
}
```

Recipe:
```json
{
  "totalRatings": 1,
  "views": 7,
  "averageRating": 5
}
```

Chef:
```json
{
  "ratings": {
    "641024": 5,
    "663849": 3
  },
  "recentRecipes": {
    "641024": "2024-10-17T02:54:07.471+00:00",
    "663849": "2024-10-17T22:28:27.387+00:00"
  },
  "favoriteRecipes": ["641024"]
}
```

This was more involved compared to the last few PRs. I went back to the recipes route to implement a new path, but this involves updating both the recipe and chef documents in MongoDB. As I was working on this, I realized that I needed to make a few small changes to my original schema to more easily add, find, and delete recipe stats from both collections. For example, recent recipes should contain the timestamp when each recipe was last viewed to avoid sorting the array every time we add or modify an item.

There are a lot of validations that need to be checked before we can accept this request since we need to pass both a body and the auth token. I did catch a few bugs with some of my existing methods and was able to fix them relatively easily.

One of the tricks I had to deal with was handling map types in mongoose. I wanted to use maps to strongly type both the key and value of the recent recipes and ratings. I would've also liked to make favorites a set, but it's not that hard to convert it to an array. Even though the map will ultimately turn into an object in MongoDB, I had to still use the map methods to add and remove items. Otherwise, the operations wouldn't occur and mongoose wouldn't complain. As a bonus, I just learned how to prevent additional _id's from being added to sub-objects. New recipes won't have these fields, but they will have the new fields set to 0/null by default. Good thing MongoDB doesn't enforce a schema. 😉

Another challenge I faced was calculating the average rating for each recipe. I gave the formula when adding a new rating in the linked issue, but I also needed to account for when the user wants to change their rating. I would need their old rating to determine the new average rating. This also meant I needed to first query the recipe for the ID, query the chef for their existing rating, and then query the recipe again to perform those calculations. All the while, I needed to account for any errors along the way.