### PR TITLE
328 add continueurl to deep link into client app

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -254,6 +254,9 @@ components:
           type: string
           description: The chef's email address
           format: email
+        emailVerified:
+          type: boolean
+          description: Whether or not the email address is verified
         ratings:
           type: object
           description: >-

--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -79,7 +79,8 @@ paths:
     patch:
       summary: >-
         Send an email to change the chef's credentials.
-        An ID token is optional if changing passwords.
+        If changing passwords and a valid ID token is provided,
+        the password will be updated immediately.
       tags:
         - chefs
       security:
@@ -93,7 +94,8 @@ paths:
               $ref: "#/components/schemas/changeRequest"
       responses:
         "200":
-          description: Successfully sent an email to verify the change request
+          description: >-
+            Successfully updated the credentials or sent an email to verify the change request
           content:
             application/json:
               schema:
@@ -305,6 +307,7 @@ components:
           description: Whether or not the email address is verified
     changeRequest:
       type: object
+      required: ["type", "email"]
       properties:
         type:
           type: string
@@ -314,6 +317,11 @@ components:
           type: string
           description: The email address to send a verification to
           format: email
+        password:
+          type: string
+          description: The new password
+          format: password
+          minLength: 8
     email:
       type: object
       # token may not be there if changing passwords

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -24,10 +24,11 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
   const token = authHeader?.startsWith("Bearer ")
     ? authHeader.split("Bearer ")[1]
     : authHeader;
-  const isChangingPassword =
+  const isResettingPassword =
     req.originalUrl === "/api/chefs" &&
     req.method === "PATCH" &&
-    req.body?.type === "password";
+    req.body?.type === "password" &&
+    req.body?.password === undefined;
   const isViewingRecipe =
     req.originalUrl.startsWith("/api/recipes/") &&
     req.params.id !== undefined &&
@@ -36,7 +37,7 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
 
   if (token === undefined) {
     // Skip validation for certain requests
-    if (isChangingPassword || isViewingRecipe) {
+    if (isResettingPassword || isViewingRecipe) {
       next();
     } else {
       res

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: EZ Recipes
   description: An API that fetches recipes from spoonacular and MongoDB
-  version: 3.0.0
+  version: 3.1.0
 
 servers:
   - url: https://ez-recipes-server.onrender.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-recipes-server",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Server to fetch easy-to-make recipes for the EZ Recipes app",
   "main": "dist/index.js",
   "scripts": {

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -60,7 +60,7 @@ router.get("/", auth, async (_req, res) => {
     const userRecord = await FirebaseAdmin.instance.getUser(uid);
     res.status(200).json({
       uid,
-      ...filterObject(userRecord, ["email"]),
+      ...filterObject(userRecord, ["email", "emailVerified"]),
       ...filterObject(chef, ["ratings", "recentRecipes", "favoriteRecipes"]),
       token,
     });

--- a/types/firebase/ContinueAction.ts
+++ b/types/firebase/ContinueAction.ts
@@ -1,0 +1,7 @@
+enum ContinueAction {
+  VERIFY_EMAIL = "verifyEmail",
+  CHANGE_EMAIL = "changeEmail",
+  RESET_PASSWORD = "resetPassword",
+}
+
+export default ContinueAction;

--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -103,6 +103,21 @@ export default class FirebaseAdmin {
   }
 
   /**
+   * Change the user's password
+   * @param uid the unique ID of the user
+   * @param password the new password to set
+   * @throws `FirebaseAuthError` if an error occurred
+   */
+  async changePassword(uid: string, password: string) {
+    const auth = getAuth();
+    const userRecord = await auth.updateUser(uid, {
+      password,
+    });
+
+    console.log(`Successfully changed the user's password:`, userRecord);
+  }
+
+  /**
    * Log out the user by revoking their tokens
    * @param uid the unique ID of the user
    * @throws `FirebaseAuthError` if an error occurred

--- a/utils/auth/api.ts
+++ b/utils/auth/api.ts
@@ -4,6 +4,7 @@ import OobCodeResponse from "../../types/firebase/OobCodeResponse";
 import FirebaseTokenResponse from "../../types/firebase/FirebaseTokenResponse";
 import FirebaseTokenExchangeResponse from "../../types/firebase/FirebaseTokenExchangeResponse";
 import FirebaseLoginResponse from "../../types/firebase/FirebaseLoginResponse";
+import ContinueAction from "../../types/firebase/ContinueAction";
 
 export default class FirebaseApi {
   private static _instance: FirebaseApi;
@@ -34,6 +35,10 @@ export default class FirebaseApi {
     }
 
     return this._instance;
+  }
+
+  private createDeepLink(action: ContinueAction) {
+    return `https://ez-recipes-web.onrender.com/profile?action=${action}`;
   }
 
   /**
@@ -87,6 +92,7 @@ export default class FirebaseApi {
       {
         requestType: "VERIFY_EMAIL",
         idToken: token,
+        continueUrl: this.createDeepLink(ContinueAction.VERIFY_EMAIL),
       }
     );
     return response.data;
@@ -104,6 +110,7 @@ export default class FirebaseApi {
       {
         requestType: "PASSWORD_RESET",
         email,
+        continueUrl: this.createDeepLink(ContinueAction.RESET_PASSWORD),
       }
     );
     return response.data;
@@ -124,6 +131,7 @@ export default class FirebaseApi {
         requestType: "VERIFY_AND_CHANGE_EMAIL",
         newEmail: email,
         idToken: token,
+        continueUrl: this.createDeepLink(ContinueAction.CHANGE_EMAIL),
       }
     );
     return response.data;


### PR DESCRIPTION
<img width="269" alt="image" src="https://github.com/user-attachments/assets/89a96f1e-4a86-4591-aadd-0f4a3c1df81b">

Fixes #328
Fixes #329 

Now there's a continue button that will redirect to the EZ Recipes web app. I added a query parameter to tell the client what kind of update was done. This might just be useful for showing a confirmation message, but could be useful elsewhere. Adding `emailVerified` to the GET response should make it easier for the client to determine if the user verified their email before showing their profile.

In the Firebase console, I had to add the web app to the list of authorized domains:
<img width="698" alt="image" src="https://github.com/user-attachments/assets/03c420d5-f391-4b1a-b834-ac830d4f351b">

We get the 404 page right now since nothing has been implemented in the web app yet, but I should be able to add the deep link logic in the mobile apps to have them automatically redirect to the profile tab.

Also, to make it easier to change passwords, you can now add a password as a parameter in the PATCH call:

```json
{
    "type": "password",
    "email": "test@email.com",
    "password": "test4321"
}
```

If the user is already logged in, sending a verification email isn't needed. I made the response consistent with all the other update types to make parsing it easier on the client side:

```json
{
    "kind": "",
    "email": "test@email.com",
    "token": "ey..."
}
```