### PR TITLE
Explicitly specify the service account path when initializing Firebase

### DIFF
--- a/utils/auth/admin.ts
+++ b/utils/auth/admin.ts
@@ -1,4 +1,5 @@
 // Need to enable allowSyntheticDefaultImports
+import { credential } from "firebase-admin";
 import { initializeApp } from "firebase-admin/app";
 import { getAuth, UserRecord } from "firebase-admin/auth";
 
@@ -10,8 +11,12 @@ export default class FirebaseAdmin {
   private static _instance: FirebaseAdmin; // singleton
 
   private constructor() {
-    // Initialize the Firebase Admin SDK using the default config
-    initializeApp();
+    // Application Default Credentials (ADC) don't work as of firebase-admin v13
+    initializeApp({
+      credential: credential.cert(
+        `${process.env.GOOGLE_APPLICATION_CREDENTIALS}`
+      ),
+    });
     console.log("Initialized the Firebase Admin SDK");
   }
 


### PR DESCRIPTION
Since the `cert` function can take in a file path, I can reuse the `GOOGLE_APPLICATION_CREDENTIALS` env var to point to the correct service account file locally and on Render.