### PR TITLE
Add axios interceptor & shorten error logs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import recipes from "./routes/recipes";
 import terms from "./routes/terms";
 import chefs from "./routes/chefs";
 import { connectToMongoDB } from "./utils/db";
+import logger from "./middleware/logger";
 
 const app = express();
 app.disable("x-powered-by"); // disable fingerprinting
@@ -20,6 +21,7 @@ app.disable("x-powered-by"); // disable fingerprinting
  * - Enable CORS
  * - Add security headers
  * - Add rate limiting
+ * - Add logging
  */
 app.use(express.json());
 app.use(
@@ -47,6 +49,7 @@ app.use(
     validate: { xForwardedForHeader: false }, // apply the limit globally
   })
 );
+app.use(logger);
 
 // Define routes
 app.use("/", docs);

--- a/middleware/logger.ts
+++ b/middleware/logger.ts
@@ -1,0 +1,20 @@
+import { NextFunction, Request, Response } from "express";
+import { redactHeadersAndFields } from "../utils/axios";
+
+const logger = (req: Request, _res: Response, next: NextFunction) => {
+  // Log all incoming requests
+  const { method, originalUrl, headers, body } = req;
+  // Logging all headers isn't needed, but may change later
+  const { dataForLogging } = redactHeadersAndFields(headers, body);
+
+  let log = `[Incoming Request] ${new Date()} | Method: ${method} | URL: ${originalUrl}`;
+  // Don't log empty request bodies
+  if (dataForLogging !== undefined) {
+    log += ` | Data: ${JSON.stringify(dataForLogging)}`;
+  }
+
+  console.log(log);
+  next();
+};
+
+export default logger;

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -41,7 +41,6 @@ const router = express.Router();
 
 // Query recipes in MongoDB
 router.get("/", async (req, res) => {
-  console.log(`${req.method} ${req.originalUrl}`);
   const {
     query,
     "min-cals": minCals,

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,10 +1,11 @@
-import axios, { AxiosError } from "axios";
+import { AxiosError } from "axios";
 
 import RecipeError from "../types/client/RecipeError";
 import { isErrorResponse } from "./recipeUtils";
+import createAxios from "./axios";
 
 // Apply all common API settings
-const spoonacularApi = axios.create({
+const spoonacularApi = createAxios({
   baseURL: "https://api.spoonacular.com/recipes",
   headers: {
     "x-api-key": process.env.API_KEY ?? "",
@@ -20,8 +21,6 @@ export const handleAxiosError = (error: AxiosError): [number, RecipeError] => {
   const errorData = error.response?.data;
 
   if (isErrorResponse(errorData)) {
-    console.error(errorData);
-
     const errorBody: RecipeError = {
       error: errorData.message,
     };
@@ -29,7 +28,6 @@ export const handleAxiosError = (error: AxiosError): [number, RecipeError] => {
   }
 
   // Try returning the raw response, otherwise return a generic Axios error
-  console.error(error);
   let errorMessage: string;
 
   if (typeof error.response?.data === "string") {

--- a/utils/auth/api.ts
+++ b/utils/auth/api.ts
@@ -1,10 +1,11 @@
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 
 import OobCodeResponse from "../../types/firebase/OobCodeResponse";
 import FirebaseTokenResponse from "../../types/firebase/FirebaseTokenResponse";
 import FirebaseTokenExchangeResponse from "../../types/firebase/FirebaseTokenExchangeResponse";
 import FirebaseLoginResponse from "../../types/firebase/FirebaseLoginResponse";
 import ContinueAction from "../../types/firebase/ContinueAction";
+import createAxios from "../axios";
 
 export default class FirebaseApi {
   private static _instance: FirebaseApi;
@@ -12,7 +13,7 @@ export default class FirebaseApi {
   private secureApi: AxiosInstance;
 
   private constructor() {
-    this.idApi = axios.create({
+    this.idApi = createAxios({
       baseURL: "https://identitytoolkit.googleapis.com/v1",
       params: {
         key: process.env.WEB_API_KEY,
@@ -20,7 +21,7 @@ export default class FirebaseApi {
       signal: new AbortController().signal,
     });
 
-    this.secureApi = axios.create({
+    this.secureApi = createAxios({
       baseURL: "https://securetoken.googleapis.com/v1",
       params: {
         key: process.env.WEB_API_KEY,

--- a/utils/axios.ts
+++ b/utils/axios.ts
@@ -1,0 +1,135 @@
+import axios, {
+  AxiosHeaderValue,
+  AxiosInstance,
+  CreateAxiosDefaults,
+  isAxiosError,
+  RawAxiosRequestHeaders,
+  RawAxiosResponseHeaders,
+} from "axios";
+import { isObject } from "./object";
+
+// Redact sensitive headers and body fields from the logs
+const MASK = "██";
+const HEADERS_TO_REDACT = ["authorization", "cookie", "x-api-key"];
+const FIELDS_TO_REDACT = ["password"];
+
+const redactHeadersAndFields = (
+  headers?: RawAxiosRequestHeaders | RawAxiosResponseHeaders,
+  data?: unknown
+): {
+  headersForLogging: typeof headers;
+  dataForLogging: typeof data;
+} => {
+  let headersForLogging;
+  let dataForLogging;
+
+  if (isObject(headers)) {
+    const headersObj = headers as Record<string, AxiosHeaderValue | undefined>;
+    headersForLogging = { ...headersObj };
+
+    for (const header of HEADERS_TO_REDACT) {
+      if (Object.hasOwn(headersObj, header)) {
+        headersForLogging[header] = MASK;
+      }
+    }
+  } else {
+    headersForLogging = headers;
+  }
+
+  if (isObject(data)) {
+    const dataObj = data as Record<string, unknown>;
+    dataForLogging = { ...dataObj };
+
+    for (const field of FIELDS_TO_REDACT) {
+      if (Object.hasOwn(dataObj, field)) {
+        dataForLogging[field] = MASK;
+      }
+    }
+  } else {
+    dataForLogging = data;
+  }
+
+  return { headersForLogging, dataForLogging };
+};
+
+/**
+ * Initialize Axios with interceptors
+ * @param config the API configuration
+ * @returns a new Axios instance
+ */
+const createAxios = (config: CreateAxiosDefaults): AxiosInstance => {
+  const axiosInstance = axios.create(config);
+
+  axiosInstance.interceptors.request.use(
+    (config) => {
+      // Log fulfilled requests
+      const { method, baseURL, url, headers, data } = config;
+      const fullUrl = (baseURL ?? "") + (url ?? "") || undefined;
+      const { headersForLogging, dataForLogging } = redactHeadersAndFields(
+        headers,
+        data
+      );
+
+      let log =
+        `[Axios Request] ${new Date()} | Method: ${method?.toUpperCase()} | URL: ${fullUrl} | ` +
+        `Headers: ${JSON.stringify(headersForLogging)}`;
+      // Don't log empty request bodies
+      if (dataForLogging !== undefined) {
+        log += ` | Data: ${JSON.stringify(dataForLogging)}`;
+      }
+
+      console.log(log);
+      return config;
+    },
+    (error) => {
+      // Log rejected requests
+      console.error(
+        "[Axios Request] Error:",
+        JSON.stringify(error, Object.getOwnPropertyNames(error), 2)
+      );
+      return Promise.reject(error);
+    }
+  );
+
+  axiosInstance.interceptors.response.use(
+    (response) => {
+      // Log fulfilled responses
+      const { method, baseURL, url } = response.config;
+      const { status } = response;
+      const fullUrl = (baseURL ?? "") + (url ?? "") || undefined;
+
+      // Don't log response bodies since they can be large and shouldn't contain any surprises
+      console.log(
+        `[Axios Response] ${new Date()} | Method: ${method?.toUpperCase()} | URL: ${fullUrl} | ` +
+          `Status: ${status}`
+      );
+      return response;
+    },
+    (error) => {
+      // Log rejected errors
+      if (isAxiosError(error)) {
+        const { code, message, config, response } = error;
+        const { method, baseURL, url } = config ?? {};
+        const { status, statusText, data } = response ?? {};
+        const fullUrl = (baseURL ?? "") + (url ?? "") || undefined;
+
+        console.log(
+          `[Axios Response] Error ${new Date()} | Method: ${method?.toUpperCase()} | ` +
+            `URL: ${fullUrl} | Status: ${status} | Status Text: ${statusText} | Code: ${code} | ` +
+            `Message: ${message} | Data: ${JSON.stringify(data)}`
+        );
+      } else {
+        console.error(
+          "[Axios Response] Error:",
+          JSON.stringify(error, Object.getOwnPropertyNames(error), 2)
+        );
+      }
+
+      return Promise.reject(error);
+    }
+  );
+
+  return axiosInstance;
+};
+
+export default createAxios;

--- a/utils/axios.ts
+++ b/utils/axios.ts
@@ -11,9 +11,9 @@ import { isObject } from "./object";
 // Redact sensitive headers and body fields from the logs
 const MASK = "██";
 const HEADERS_TO_REDACT = ["authorization", "cookie", "x-api-key"];
-const FIELDS_TO_REDACT = ["password"];
+const FIELDS_TO_REDACT = ["password", "refresh_token"];
 
-const redactHeadersAndFields = (
+export const redactHeadersAndFields = (
   headers?: RawAxiosRequestHeaders | RawAxiosResponseHeaders,
   data?: unknown
 ): {

--- a/utils/recipeUtils.ts
+++ b/utils/recipeUtils.ts
@@ -294,9 +294,10 @@ const stripURL = (image: string): string => {
   try {
     const imageUrl = new URL(image);
     return imageUrl.pathname.split("/").at(-1) ?? image;
-  } catch (error) {
+  } catch (err) {
     // Invalid URL
-    console.warn(`Failed to strip image URL (${image})`, error);
+    const error = err as Error;
+    console.warn(`Failed to strip image URL (${image}): ${error.message}`);
     return image;
   }
 };


### PR DESCRIPTION
This will record all 3rd party API calls and reduce the error logs to make searching in Render easier. I also redacted sensitive headers and request fields like in the Android app.

**Edit:** Now I'm logging all requests coming to the server. I may consider moving verbose logs to a separate level in the future.