### PR TITLE
425 save the access token in a cookie for the web app

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -6,6 +6,7 @@ paths:
         - chefs
       security:
         - bearerAuth: [] # no scopes for bearer auth
+        - cookieAuth: []
       responses:
         "200":
           description: Successfully fetched the chef's profile
@@ -51,6 +52,10 @@ paths:
       responses:
         "201":
           description: Successfully created a new account
+          headers:
+            Set-Cookie:
+              schema:
+                $ref: "#/components/schemas/idTokenCookie"
           content:
             application/json:
               schema:
@@ -130,6 +135,10 @@ paths:
       responses:
         "204":
           description: Successfully deleted the account
+          headers:
+            Set-Cookie:
+              schema:
+                $ref: "#/components/schemas/idTokenClearCookie"
 
         "401":
           description: The token passed is invalid
@@ -199,6 +208,10 @@ paths:
       responses:
         "200":
           description: Successfully logged in
+          headers:
+            Set-Cookie:
+              schema:
+                $ref: "#/components/schemas/idTokenCookie"
           content:
             application/json:
               schema:
@@ -226,6 +239,10 @@ paths:
       responses:
         "204":
           description: Successfully logged out
+          headers:
+            Set-Cookie:
+              schema:
+                $ref: "#/components/schemas/idTokenClearCookie"
 
         "401":
           description: The token passed is invalid
@@ -337,6 +354,12 @@ components:
         token:
           type: string
           description: The ID token for the chef
+    idTokenCookie:
+      type: string
+      example: idToken=eyJ...; Max-Age=2592000; Path=/; Expires=Mon, 22 Sep 2025 22:04:07 GMT; HttpOnly; Secure; SameSite=Strict
+    idTokenClearCookie:
+      type: string
+      example: idToken=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; Secure; SameSite=Strict
 
   examples:
     invalidEmail:

--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -287,6 +287,7 @@ paths:
       security:
         - {} # no security
         - bearerAuth: []
+        - cookieAuth: []
       parameters:
         - $ref: "#/components/parameters/recipeId"
       requestBody:

--- a/index.ts
+++ b/index.ts
@@ -31,6 +31,8 @@ app.use(
   cors({
     // Only allow the web app & local server to access the server in the browser
     origin: ["http://localhost:4200", "https://ez-recipes-web.onrender.com"],
+    // Required to allow browsers to send cookies
+    credentials: true,
   })
 );
 app.use(

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import cookieParser from "cookie-parser";
 import cors from "cors";
 import "dotenv/config"; // fetch secrets from .env
 import express from "express";
@@ -17,6 +18,7 @@ app.disable("x-powered-by"); // disable fingerprinting
 /**
  * Initialize middleware:
  * - Parse JSON
+ * - Parse cookies
  * - Serve Swagger UI files
  * - Enable CORS
  * - Add security headers
@@ -24,6 +26,7 @@ app.disable("x-powered-by"); // disable fingerprinting
  * - Add logging
  */
 app.use(express.json());
+app.use(cookieParser());
 app.use(
   cors({
     // Only allow the web app & local server to access the server in the browser

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -5,7 +5,7 @@ import { jwtDecode } from "jwt-decode";
 import FirebaseAdmin from "../utils/auth/admin";
 import FirebaseApi from "../utils/auth/api";
 import { getRefreshToken, saveRefreshToken } from "../utils/db";
-import { COOKIE_30_DAYS, COOKIES } from "../utils/cookie";
+import { BASE_COOKIE_OPTIONS, COOKIE_30_DAYS, COOKIES } from "../utils/cookie";
 
 const saveTokenAndContinue = (
   res: Response,
@@ -96,6 +96,7 @@ const auth = async (req: Request, res: Response, next: NextFunction) => {
       }
     }
 
+    res.clearCookie(COOKIES.ID_TOKEN, BASE_COOKIE_OPTIONS);
     res
       .status(401)
       .json({ error: `Invalid Firebase token provided: ${error}` });

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,6 +45,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: idToken
 
   schemas:
     recipes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.11.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -25,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
@@ -2124,6 +2126,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -3716,12 +3728,32 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.1",
@@ -11551,6 +11583,13 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "requires": {}
+    },
     "@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -12649,9 +12688,25 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
+    },
+    "cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "requires": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie-signature": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "homepage": "https://github.com/Abhiek187/ez-recipes-server#readme",
   "dependencies": {
     "axios": "^1.11.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
@@ -48,6 +49,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",

--- a/tests/auth-middleware.test.ts
+++ b/tests/auth-middleware.test.ts
@@ -14,15 +14,19 @@ const mockRequest = (authorization?: string, req?: object) =>
       authorization,
     },
   } as Request);
+
 const mockJson = jest.fn();
 const mockStatus = jest.fn().mockReturnValue({ json: mockJson });
 const mockCookie = jest.fn();
+const mockClearCookie = jest.fn();
 const mockResponse = {
   status: mockStatus,
   json: mockJson,
   locals: {},
   cookie: mockCookie,
+  clearCookie: mockClearCookie,
 } as unknown as Response;
+
 const mockNext = jest.fn();
 
 const mockValidateToken = (
@@ -138,6 +142,7 @@ describe("auth-middleware", () => {
     await auth(mockRequest("mock-invalid-jwt"), mockResponse, mockNext);
 
     expect(mockCookie).not.toHaveBeenCalled();
+    expect(mockClearCookie).toHaveBeenCalled();
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toHaveBeenCalled();
@@ -152,6 +157,7 @@ describe("auth-middleware", () => {
 
     expect(jwtDecodeSpy).toHaveBeenCalledWith(mockToken);
     expect(mockCookie).not.toHaveBeenCalled();
+    expect(mockClearCookie).toHaveBeenCalled();
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toHaveBeenCalled();
@@ -166,6 +172,7 @@ describe("auth-middleware", () => {
 
     expect(jwtDecodeSpy).toHaveBeenCalledWith(mockToken);
     expect(mockCookie).not.toHaveBeenCalled();
+    expect(mockClearCookie).toHaveBeenCalled();
     expect(mockNext).not.toHaveBeenCalled();
     expect(mockResponse.status).toHaveBeenCalledWith(401);
     expect(mockResponse.json).toHaveBeenCalled();

--- a/utils/cookie.ts
+++ b/utils/cookie.ts
@@ -1,0 +1,16 @@
+import { CookieOptions } from "express";
+
+export const COOKIES = {
+  ID_TOKEN: "idToken",
+} as const;
+
+export const BASE_COOKIE_OPTIONS: CookieOptions = {
+  httpOnly: true, // inaccessible via document.cookie, prevents XSS
+  secure: true, // only sent in HTTPS requests
+  sameSite: "strict", // only sent on sites with the same domain, prevents CSRF
+};
+
+export const COOKIE_30_DAYS: CookieOptions = {
+  ...BASE_COOKIE_OPTIONS,
+  maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+};


### PR DESCRIPTION
To enhance the web app's security, I added an HTTP-only, secure, and strict same-site `idToken` cookie to the response. This is created when logging in or creating an account, and is cleared when logging out or deleting an account. (Funnily enough, cookies are "cleared" by setting their expiration date to Jan 1, 1970.) The auth middleware also updates the cookie whenever the token is refreshed. If the token isn't valid, the cookie is cleared. I set the cookie to expire after 30 days, so users can keep their sessions active on subsequent visits. I updated the OpenAPI spec to indicate how the cookie will be sent back in the Set-Cookie header, as well as how it's cleared (note that cookie auth isn't supported in Swagger UI for security reasons):

<img width="841" height="291" alt="image" src="https://github.com/user-attachments/assets/b4ddc819-9145-46bf-9dc9-0cd803dd5b6e" />
<img width="836" height="220" alt="image" src="https://github.com/user-attachments/assets/ec51ae42-fd21-4f40-ad55-382324ea451f" />

This shouldn't impact the mobile apps since they will still rely on the authorization header to store the tokens on-device.

When I was testing the cookie on the web app via localhost, the browser wasn't saving the cookie despite it appearing in the response header. This is because CORS requests don't send cookies by default. First, the browser needs to enable `useCredentials` when making an API request (this can be done using XHR, fetch, Axios, Angular, etc.). Then, when it makes a preflight request, the server must set `Access-Control-Allow-Credentials` to true. This doesn't work if `Access-Control-Allow-Origin` is a wildcard, so it's a good thing I specified each domain. As usual, these headers don't apply to Postman or mobile apps.

All the other security settings worked fine on localhost, but I'll need to test this in prod on various browsers to make sure the cookies are still saved. I heard cookie management can be tricky on Safari. `SameSite=Strict` _should_ still work in prod since both the server and web app are hosted under the `render.com` **site** (but different origins).