### PR TITLE
369 sort search results

### DIFF
--- a/docs/recipes.yaml
+++ b/docs/recipes.yaml
@@ -172,6 +172,22 @@ paths:
             A token used to paginate results.
             If no query is passed, this is the ObjectId of the recipe to search after.
             If a query is passed, this is the token returned from a previous query.
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum:
+              - calories
+              - health-score
+              - rating
+              - views
+          description: The field to sort by
+        - in: query
+          name: asc
+          schema:
+            type: boolean
+          allowEmptyValue: true
+          description: If provided, sort the sort field in ascending order. Otherwise, sort in descending order.
       responses:
         "200":
           description: Successfully filtered recipes

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -144,7 +144,10 @@ router.get("/", async (req, res) => {
   if (typeof token === "string") {
     // If sorting & paginating, check if the compound token is valid
     // Compound token format: sort_field:last_value:object_id
-    if (filter.sort !== undefined) {
+    if (
+      filter.sort !== undefined &&
+      (filter.query === undefined || filter.sort === "calories")
+    ) {
       const [sortField, lastValue, objectId] = token.split(":");
 
       if (

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -23,7 +23,10 @@ import {
   updateChef,
   updateRecipeStats,
 } from "../utils/db";
-import RecipeFilter from "../types/client/RecipeFilter";
+import RecipeFilter, {
+  isValidSortField,
+  RECIPE_SORT_MAP,
+} from "../types/client/RecipeFilter";
 import {
   isValidSpiceLevel,
   isValidMealType,
@@ -57,6 +60,8 @@ router.get("/", async (req, res) => {
     type,
     culture,
     token,
+    sort,
+    asc,
   } = req.query;
   const filter: Partial<RecipeFilter> = {};
 
@@ -99,6 +104,10 @@ router.get("/", async (req, res) => {
     filter.sustainable = true;
   }
 
+  if (asc !== undefined) {
+    filter.asc = true;
+  }
+
   try {
     // If the query parameter appears once, it's a string
     // Otherwise, it's an array of strings
@@ -123,14 +132,32 @@ router.get("/", async (req, res) => {
     } else if (Array.isArray(culture)) {
       filter.cultures = sanitizeEnumArray(culture, "cuisine", isValidCuisine);
     }
+
+    if (typeof sort === "string") {
+      filter.sort = sanitizeEnum(sort, "sort", isValidSortField);
+    }
   } catch (error) {
     badRequestError(res, error as string);
     return;
   }
 
   if (typeof token === "string") {
+    // If sorting & paginating, check if the compound token is valid
+    // Compound token format: sort_field:last_value:object_id
+    if (filter.sort !== undefined) {
+      const [sortField, lastValue, objectId] = token.split(":");
+
+      if (
+        sortField !== RECIPE_SORT_MAP[filter.sort] ||
+        lastValue === undefined ||
+        objectId === undefined
+      ) {
+        badRequestError(res, `Token "${token}" is not a valid compound token`);
+        return;
+      }
+    }
     // An ObjectId must be passed if a find query should be performed
-    if (filter.query === undefined && !isValidObjectId(token)) {
+    else if (filter.query === undefined && !isValidObjectId(token)) {
       badRequestError(res, `Token "${token}" is not a valid ObjectId`);
       return;
     }

--- a/routes/recipes.ts
+++ b/routes/recipes.ts
@@ -153,7 +153,7 @@ router.get("/", async (req, res) => {
       if (
         sortField !== RECIPE_SORT_MAP[filter.sort] ||
         lastValue === undefined ||
-        objectId === undefined
+        !isValidObjectId(objectId)
       ) {
         badRequestError(res, `Token "${token}" is not a valid compound token`);
         return;

--- a/tests/db-recipes.test.ts
+++ b/tests/db-recipes.test.ts
@@ -1,14 +1,21 @@
 import { FilterQuery, Types } from "mongoose";
 
 import RecipeModel from "../models/RecipeModel";
-import RecipeFilter from "../types/client/RecipeFilter";
+import RecipeFilter, {
+  RECIPE_SORT_FIELDS,
+  RECIPE_SORT_MAP,
+} from "../types/client/RecipeFilter";
 import { Indexes, MAX_DOCS, filterRecipes } from "../utils/db";
 import Recipe from "../types/client/Recipe";
 
+const defaultSort = { _id: 1 };
+
 describe("recipeFindQuery", () => {
   const mockExec = jest.fn();
-  const mockLimit = jest.fn().mockReturnValue({ exec: mockExec });
-  const mockFind = jest.fn().mockReturnValue({ limit: mockLimit });
+  const mockLean = jest.fn().mockReturnValue({ exec: mockExec });
+  const mockLimit = jest.fn().mockReturnValue({ lean: mockLean });
+  const mockSort = jest.fn().mockReturnValue({ limit: mockLimit });
+  const mockFind = jest.fn().mockReturnValue({ sort: mockSort });
   jest.spyOn(RecipeModel, "find").mockImplementation(mockFind);
 
   it("accepts no filter", async () => {
@@ -17,6 +24,7 @@ describe("recipeFindQuery", () => {
     await filterRecipes({});
     // Then the query is also empty
     expect(mockFind).toHaveBeenCalledWith({});
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -41,6 +49,7 @@ describe("recipeFindQuery", () => {
       },
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -58,6 +67,7 @@ describe("recipeFindQuery", () => {
       isSustainable: filter.sustainable,
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -75,6 +85,7 @@ describe("recipeFindQuery", () => {
       culture: { $in: filter.cultures },
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -105,6 +116,7 @@ describe("recipeFindQuery", () => {
       spiceLevel: { $in: filter.spiceLevels },
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -151,6 +163,7 @@ describe("recipeFindQuery", () => {
       culture: { $in: filter.cultures },
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
 
@@ -170,18 +183,142 @@ describe("recipeFindQuery", () => {
       },
     };
     expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+    expect(mockSort).toHaveBeenCalledWith(defaultSort);
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
   });
+
+  it.each(RECIPE_SORT_FIELDS)(
+    "sorts by %s in descending order",
+    async (sortField) => {
+      // Given a filter with a sort field
+      const filter: Partial<RecipeFilter> = {
+        sort: sortField,
+      };
+
+      // When filterRecipes is called
+      await filterRecipes(filter);
+
+      // Then the query is sorted in descending order by the correct field
+      const expectedSort = {
+        [RECIPE_SORT_MAP[sortField]]: -1,
+        ...defaultSort,
+      };
+      expect(mockFind).toHaveBeenCalledWith({});
+      expect(mockSort).toHaveBeenCalledWith(expectedSort);
+      expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    }
+  );
+
+  it.each(RECIPE_SORT_FIELDS)(
+    "sorts by %s in ascending order",
+    async (sortField) => {
+      // Given a filter with a sort and asc field
+      const filter: Partial<RecipeFilter> = {
+        sort: sortField,
+        asc: true,
+      };
+
+      // When filterRecipes is called
+      await filterRecipes(filter);
+
+      // Then the query is sorted in ascending order by the correct field
+      const expectedSort = {
+        [RECIPE_SORT_MAP[sortField]]: 1,
+        ...defaultSort,
+      };
+      expect(mockFind).toHaveBeenCalledWith({});
+      expect(mockSort).toHaveBeenCalledWith(expectedSort);
+      expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    }
+  );
+
+  it.each(RECIPE_SORT_FIELDS)(
+    "sorts by %s in descending order with a compound token",
+    async (sortField) => {
+      // Given a filter with a sort and token field
+      const mockToken = `${RECIPE_SORT_MAP[sortField]}:null:660f1af0b5ba9017ad8e5079`;
+      const filter: Partial<RecipeFilter> = {
+        sort: sortField,
+        token: mockToken,
+      };
+
+      // When filterRecipes is called
+      await filterRecipes(filter);
+
+      // Then the query uses the compound token and is sorted in descending order
+      const [expectedSortField, , expectedObjectId] = mockToken.split(":");
+      const expectedQuery: FilterQuery<Recipe> = {
+        $or: [
+          {
+            [expectedSortField]: null,
+            _id: {
+              $gt: new Types.ObjectId(expectedObjectId),
+            },
+          },
+        ],
+      };
+      const expectedSort = {
+        [RECIPE_SORT_MAP[sortField]]: -1,
+        ...defaultSort,
+      };
+      expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+      expect(mockSort).toHaveBeenCalledWith(expectedSort);
+      expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    }
+  );
+
+  it.each(RECIPE_SORT_FIELDS)(
+    "sorts by %s in ascending order with a compound token",
+    async (sortField) => {
+      // Given a filter with a sort, asc, and token field
+      const mockToken = `${RECIPE_SORT_MAP[sortField]}:0:660f1af0b5ba9017ad8e5079`;
+      const filter: Partial<RecipeFilter> = {
+        sort: sortField,
+        asc: true,
+        token: mockToken,
+      };
+
+      // When filterRecipes is called
+      await filterRecipes(filter);
+
+      // Then the query uses the compound token and is sorted in ascending order
+      const [expectedSortField, expectedLastValue, expectedObjectId] =
+        mockToken.split(":");
+      const expectedQuery: FilterQuery<Recipe> = {
+        $or: [
+          {
+            [expectedSortField]: { $gt: Number(expectedLastValue) },
+          },
+          {
+            [expectedSortField]: Number(expectedLastValue),
+            _id: {
+              $gt: new Types.ObjectId(expectedObjectId),
+            },
+          },
+        ],
+      };
+      const expectedSort = {
+        [RECIPE_SORT_MAP[sortField]]: -1,
+        ...defaultSort,
+      };
+      expect(mockFind).toHaveBeenCalledWith(expectedQuery);
+      expect(mockSort).toHaveBeenCalledWith(expectedSort);
+      expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    }
+  );
 });
 
 describe("recipeAggregateQuery", () => {
   const mockExec = jest.fn();
   const mockAddFields = jest.fn().mockReturnValue({ exec: mockExec });
   const mockLimit = jest.fn().mockReturnValue({ addFields: mockAddFields });
-  const mockMatch = jest.fn().mockReturnValue({ limit: mockLimit });
+  const mockSort = jest.fn().mockReturnValue({ limit: mockLimit });
+  const mockMatch = jest
+    .fn()
+    .mockReturnValue({ limit: mockLimit, sort: mockSort });
   const mockSearch = jest
     .fn()
-    .mockReturnValue({ match: mockMatch, limit: mockLimit });
+    .mockReturnValue({ match: mockMatch, sort: mockSort, limit: mockLimit });
   const mockAggregate = jest.fn().mockReturnValue({ search: mockSearch });
   jest.spyOn(RecipeModel, "aggregate").mockImplementation(mockAggregate);
 
@@ -203,8 +340,10 @@ describe("recipeAggregateQuery", () => {
           wildcard: "*",
         },
       },
+      sort: defaultSort,
     });
     expect(mockMatch).not.toHaveBeenCalled();
+    expect(mockSort).not.toHaveBeenCalled();
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
     expect(mockAddFields).toHaveBeenCalledWith({
       token: {
@@ -233,8 +372,10 @@ describe("recipeAggregateQuery", () => {
         },
       },
       searchAfter: filter.token,
+      sort: defaultSort,
     });
     expect(mockMatch).not.toHaveBeenCalled();
+    expect(mockSort).not.toHaveBeenCalled();
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
     expect(mockAddFields).toHaveBeenCalledWith({
       token: {
@@ -262,10 +403,12 @@ describe("recipeAggregateQuery", () => {
           wildcard: "*",
         },
       },
+      sort: defaultSort,
     });
     expect(mockMatch).toHaveBeenCalledWith({
       isVegetarian: filter.vegetarian,
     });
+    expect(mockSort).not.toHaveBeenCalled();
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
     expect(mockAddFields).toHaveBeenCalledWith({
       token: {
@@ -297,6 +440,7 @@ describe("recipeAggregateQuery", () => {
           wildcard: "*",
         },
       },
+      sort: defaultSort,
     });
     expect(mockMatch).toHaveBeenCalledWith({
       nutrients: {
@@ -311,6 +455,120 @@ describe("recipeAggregateQuery", () => {
       isSustainable: filter.sustainable,
       spiceLevel: { $in: filter.spiceLevels },
       culture: { $in: filter.cultures },
+    });
+    expect(mockSort).not.toHaveBeenCalled();
+    expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    expect(mockAddFields).toHaveBeenCalledWith({
+      token: {
+        $meta: "searchSequenceToken",
+      },
+    });
+  });
+
+  it("adds $sort when sorting by calories", async () => {
+    // Given a recipe filter with a query and calories sort
+    const filter: Partial<RecipeFilter> = {
+      query: "tacos",
+      sort: "calories",
+    };
+
+    // When filterRecipes is called
+    await filterRecipes(filter);
+
+    // Then the $search and $sort stages are used
+    expect(mockSearch).toHaveBeenCalledWith({
+      index: Indexes.RecipeName,
+      text: {
+        query: filter.query,
+        path: {
+          wildcard: "*",
+        },
+      },
+    });
+    expect(mockSort).toHaveBeenCalledWith({
+      [RECIPE_SORT_MAP["calories"]]: -1,
+      ...defaultSort,
+    });
+    expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    expect(mockAddFields).toHaveBeenCalledWith({
+      token: {
+        $meta: "searchSequenceToken",
+      },
+    });
+  });
+
+  it("adds $match and $sort when sorting by calories with a compound token", async () => {
+    // Given a recipe filter with a query, calories sort, and token
+    const mockToken = `${RECIPE_SORT_MAP["calories"]}:null:660f1af0b5ba9017ad8e5079`;
+    const filter: Partial<RecipeFilter> = {
+      query: "tacos",
+      sort: "calories",
+      asc: true,
+      token: mockToken,
+    };
+
+    // When filterRecipes is called
+    await filterRecipes(filter);
+
+    // Then the $search, $match, and $sort stages are used
+    expect(mockSearch).toHaveBeenCalledWith({
+      index: Indexes.RecipeName,
+      text: {
+        query: filter.query,
+        path: {
+          wildcard: "*",
+        },
+      },
+    });
+    const [expectedSortField, , expectedObjectId] = mockToken.split(":");
+    expect(mockMatch).toHaveBeenCalledWith({
+      $or: [
+        {
+          [expectedSortField]: { $gt: 0 },
+        },
+        {
+          [expectedSortField]: null,
+          _id: {
+            $gt: new Types.ObjectId(expectedObjectId),
+          },
+        },
+      ],
+    });
+    expect(mockSort).toHaveBeenCalledWith({
+      [RECIPE_SORT_MAP["calories"]]: 1,
+      ...defaultSort,
+    });
+    expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
+    expect(mockAddFields).toHaveBeenCalledWith({
+      token: {
+        $meta: "searchSequenceToken",
+      },
+    });
+  });
+
+  it("adds sort to $search when sorting by simple fields", async () => {
+    // Given a recipe filter with a query and calories sort
+    const filter: Partial<RecipeFilter> = {
+      query: "tacos",
+      sort: "health-score",
+    };
+
+    // When filterRecipes is called
+    await filterRecipes(filter);
+
+    // Then the $search is used with sort
+    expect(mockSearch).toHaveBeenCalledWith({
+      index: Indexes.RecipeName,
+      text: {
+        query: filter.query,
+        path: {
+          wildcard: "*",
+        },
+      },
+      sort: {
+        [RECIPE_SORT_MAP["health-score"]]: -1,
+        ...defaultSort,
+      },
     });
     expect(mockLimit).toHaveBeenCalledWith(MAX_DOCS);
     expect(mockAddFields).toHaveBeenCalledWith({

--- a/types/client/RecipeFilter.ts
+++ b/types/client/RecipeFilter.ts
@@ -1,12 +1,5 @@
 import { Cuisine, MealType, SpiceLevel } from "./Recipe";
 
-export const RECIPE_SORT_MAP = {
-  // Calories will always be the first element in nutrients
-  calories: "nutrients.0.amount",
-  "health-score": "healthScore",
-  rating: "averageRating",
-  views: "views",
-};
 export const RECIPE_SORT_FIELDS = [
   "calories",
   "health-score",
@@ -16,6 +9,13 @@ export const RECIPE_SORT_FIELDS = [
 export type RecipeSortField = (typeof RECIPE_SORT_FIELDS)[number];
 export const isValidSortField = (str: string): str is RecipeSortField => {
   return RECIPE_SORT_FIELDS.includes(str as RecipeSortField);
+};
+export const RECIPE_SORT_MAP: Record<RecipeSortField, string> = {
+  // Calories will always be the first element in nutrients
+  calories: "nutrients.0.amount",
+  "health-score": "healthScore",
+  rating: "averageRating",
+  views: "views",
 };
 
 type RecipeFilter = {

--- a/types/client/RecipeFilter.ts
+++ b/types/client/RecipeFilter.ts
@@ -1,5 +1,23 @@
 import { Cuisine, MealType, SpiceLevel } from "./Recipe";
 
+export const RECIPE_SORT_MAP = {
+  // Calories will always be the first element in nutrients
+  calories: "nutrients.0.amount",
+  "health-score": "healthScore",
+  rating: "averageRating",
+  views: "views",
+};
+export const RECIPE_SORT_FIELDS = [
+  "calories",
+  "health-score",
+  "rating",
+  "views",
+] as const;
+export type RecipeSortField = (typeof RECIPE_SORT_FIELDS)[number];
+export const isValidSortField = (str: string): str is RecipeSortField => {
+  return RECIPE_SORT_FIELDS.includes(str as RecipeSortField);
+};
+
 type RecipeFilter = {
   query: string;
   minCals: number;
@@ -15,6 +33,8 @@ type RecipeFilter = {
   types: MealType[];
   cultures: Cuisine[];
   token?: string; // either an ObjectId or searchSequenceToken for pagination
+  sort?: RecipeSortField;
+  asc?: boolean;
 };
 
 export default RecipeFilter;


### PR DESCRIPTION
I added support for sorting by calories, health score, ratings, and views. I discussed the complications in #369, but ultimately decided to continue using cursor-based pagination.

The big issue I encountered while testing is that the `sort` option in the `$search` doesn't work if we supply positional arguments for sorting by calories (i.e., `nutrients.0.amount`). I guess it's a limitation, so I had to add custom logic to apply the same logic from the find queries if we're sorting by calories using full-text search. All the other fields can be sorted directly in the `$search` stage and we can continue using the search token in paginated requests.

The compound token will have the following format: `SORT_FIELD:LAST_VALUE:OBJECT_ID`. This gives us all the information we need to paginate the results. I chose this format to distinguish it from Object IDs (hexadecimal) and search tokens (base 64). Plus, I can validate each value in the token in context with the request.

This PR will also introduce a small change to existing searches. As mentioned in the corresponding issue, I realized that I can make search results more stable if I sort by the object ID. It seems like MongoDB is already doing that implicitly, but it's not guaranteed based on their docs. As a result, this shouldn't have much impact on the existing apps.