### PR TITLE
Add API to update the passkey name; bump version to 3.3.1

### DIFF
--- a/docs/chefs.yaml
+++ b/docs/chefs.yaml
@@ -508,6 +508,57 @@ paths:
                 $ref: "..#/components/schemas/error"
 
   /passkey:
+    patch:
+      summary: Update the name of a passkey
+      tags:
+        - chefs
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/passkeyUpdate"
+      responses:
+        "200":
+          description: Succesfully updated the passkey
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/token"
+
+        "400":
+          description: The request body is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
+        "401":
+          description: The token passed is invalid
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+              examples:
+                missingToken:
+                  $ref: "#/components/examples/missingToken"
+
+        "404":
+          description: The passkey couldn't be found
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
+        "500":
+          description: An error occurred while updating the passkey
+          content:
+            application/json:
+              schema:
+                $ref: "..#/components/schemas/error"
+
     delete:
       summary: Remove a passkey
       tags:
@@ -968,6 +1019,15 @@ components:
           type: string
           required: true
           enum: ["public-key"]
+    passkeyUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The passkey ID
+        name:
+          type: string
+          description: The new name for the passkey
 
   examples:
     invalidEmail:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.1.0
 info:
   title: EZ Recipes
   description: An API that fetches recipes from spoonacular and MongoDB
-  version: 3.3.0
+  version: 3.3.1
 
 servers:
   - url: https://ez-recipes-server.onrender.com
@@ -111,3 +111,5 @@ components:
       $ref: "./docs/chefs.yaml#/components/schemas/passkeyRequestOptions"
     passkeyClientResponse:
       $ref: "./docs/chefs.yaml#/components/schemas/passkeyClientResponse"
+    passkeyUpdate:
+      $ref: "./docs/chefs.yaml#/components/schemas/passkeyUpdate"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ez-recipes-server",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ez-recipes-server",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "ISC",
       "dependencies": {
         "@huggingface/transformers": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ez-recipes-server",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Server to fetch easy-to-make recipes for the EZ Recipes app",
   "main": "dist/index.js",
   "scripts": {

--- a/routes/chefs.ts
+++ b/routes/chefs.ts
@@ -27,6 +27,7 @@ import {
   savePasskey,
   saveRefreshToken,
   updatePasskeyCounter,
+  updatePasskeyName,
 } from "../utils/db";
 import { filterObject } from "../utils/object";
 import { BASE_COOKIE_OPTIONS, COOKIE_2_WEEKS, COOKIES } from "../utils/cookie";
@@ -731,6 +732,43 @@ router.post(
       res
         .status(500)
         .json({ error: `Failed to verify the passkey: ${error.message}` });
+    }
+  }
+);
+
+router.patch(
+  "/passkey",
+  body().isObject().withMessage("Body is missing or not an object"),
+  body("id")
+    .isString()
+    .withMessage("Passkey ID is not a string")
+    .notEmpty()
+    .withMessage("Passkey ID is required"),
+  body("name")
+    .isString()
+    .withMessage("Passkey name is not a string")
+    .notEmpty()
+    .withMessage("Passkey name is required"),
+  auth,
+  async (req, res) => {
+    checkValidations(req, res);
+    if (res.writableEnded) return;
+
+    const { id, name } = req.body;
+    const { token, uid } = res.locals;
+
+    try {
+      await updatePasskeyName(uid, id, name);
+      res.status(200).json({ token });
+    } catch (err) {
+      const error = err as Error;
+      console.error("Error updating the passkey name:", error);
+
+      if (error.message.includes("Couldn't find passkey")) {
+        res.status(404).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: error.message });
+      }
     }
   }
 );

--- a/utils/db/chefs.ts
+++ b/utils/db/chefs.ts
@@ -237,6 +237,31 @@ export const updatePasskeyCounter = async (
 };
 
 /**
+ * Change the name of a passkey
+ * @param uid the UID of the chef
+ * @param passkeyId the ID of the passkey
+ * @param newName the new passkey name
+ */
+export const updatePasskeyName = async (
+  uid: string,
+  passkeyId: string,
+  newName: string
+) => {
+  const doc = await ChefModel.findById(uid).exec();
+  const passkeyIndex = doc?.passkeys?.findIndex((pk) => pk.id === passkeyId);
+  if (doc === null || passkeyIndex === undefined || passkeyIndex === -1) {
+    throw new Error(`Couldn't find passkey ${passkeyId} for chef ${uid}`);
+  }
+
+  doc.passkeys[passkeyIndex].name = newName;
+  await doc.save();
+
+  console.log(
+    `Successfully updated the passkey name for chef ${uid}, ${passkeyId} --> ${newName}`
+  );
+};
+
+/**
  * Delete the chef's passkey
  * @param uid the UID of the chef
  * @param passkeyId the ID of the passkey


### PR DESCRIPTION
<img width="707" height="371" alt="update-passkey-openapi" src="https://github.com/user-attachments/assets/08f59b42-1b74-46ea-ac56-9961aee76ed1" />
<img width="707" height="461" alt="update-passkey-postman" src="https://github.com/user-attachments/assets/92a31ecd-fb27-43fc-a640-21e2e5d91e3d" />
<img width="655" height="196" alt="update-passkey-mongodb" src="https://github.com/user-attachments/assets/d4eb954e-3dfe-4d34-bd6a-c929b40a1a5f" />
<img width="206" height="49" alt="update-passkey-web" src="https://github.com/user-attachments/assets/b82ae8b6-0218-4514-be01-9a57dbcafad8" />

_The server implementation of https://github.com/Abhiek187/ez-recipes-web/issues/558_

A new API was created `PATCH /api/chefs/passkey` to update the passkey name. It should be straightforward to implement client-side. Once this is good, we can publish a new patch version since there's not much else planned work ahead.